### PR TITLE
feat: impl error boundary for sdk

### DIFF
--- a/ui/components/AnchorErrorBoundary.tsx
+++ b/ui/components/AnchorErrorBoundary.tsx
@@ -1,0 +1,289 @@
+import React, { Component, ReactNode } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AnchorKitError {
+  message: string;
+  code?: string | number;
+  context?: Record<string, unknown>;
+}
+
+export interface AnchorErrorBoundaryProps {
+  /** Component(s) to render when no error is present */
+  children: ReactNode;
+  /** Custom fallback UI. Receives the caught error + reset handler. */
+  fallback?: (error: AnchorKitError, reset: () => void) => ReactNode;
+  /** Called whenever an error is caught — use for logging / analytics */
+  onError?: (error: AnchorKitError, errorInfo: React.ErrorInfo) => void;
+  /** Optional label shown in the default fallback (e.g. "Anchor Feed", "Price Widget") */
+  componentLabel?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: AnchorKitError | null;
+}
+
+// ─── Normalise any thrown value into an AnchorKitError ────────────────────────
+
+function normaliseError(raw: unknown): AnchorKitError {
+  if (raw instanceof Error) {
+    return {
+      message: raw.message,
+      code: (raw as Error & { code?: string | number }).code,
+    };
+  }
+  if (typeof raw === "object" && raw !== null && "message" in raw) {
+    return raw as AnchorKitError;
+  }
+  return { message: String(raw) };
+}
+
+// ─── Default Fallback UI ──────────────────────────────────────────────────────
+
+function DefaultFallback({
+  error,
+  reset,
+  label,
+}: {
+  error: AnchorKitError;
+  reset: () => void;
+  label?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style={{
+        fontFamily: "'DM Mono', 'Courier New', monospace",
+        background: "#0a0a0a",
+        border: "1px solid #1f1f1f",
+        borderLeft: "3px solid #ff4d6d",
+        borderRadius: 2,
+        padding: "20px 24px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        minWidth: 280,
+        maxWidth: 480,
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 28,
+            height: 28,
+            border: "1px solid #ff4d6d",
+            color: "#ff4d6d",
+            fontSize: 13,
+            flexShrink: 0,
+          }}
+        >
+          ✕
+        </span>
+        <div>
+          <div
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.2em",
+              color: "#ff4d6d",
+              marginBottom: 2,
+            }}
+          >
+            ANCHOR SDK — COMPONENT FAILURE
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              color: "#e0e0e0",
+              letterSpacing: "-0.01em",
+            }}
+          >
+            {label ?? "SDK Component"} unavailable
+          </div>
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div style={{ height: 1, background: "#1a1a1a" }} />
+
+      {/* Error detail */}
+      <div
+        style={{
+          background: "#050505",
+          border: "1px solid #161616",
+          padding: "10px 14px",
+          fontSize: 11,
+          color: "#666",
+          letterSpacing: "0.02em",
+          lineHeight: 1.6,
+          wordBreak: "break-word",
+        }}
+      >
+        <span style={{ color: "#ff4d6d", marginRight: 6 }}>
+          {error.code ? `[${error.code}]` : "[ERR]"}
+        </span>
+        {error.message}
+      </div>
+
+      {/* Context dump (optional) */}
+      {error.context && Object.keys(error.context).length > 0 && (
+        <details style={{ fontSize: 10, color: "#444", cursor: "pointer" }}>
+          <summary style={{ letterSpacing: "0.1em", outline: "none" }}>
+            CONTEXT
+          </summary>
+          <pre
+            style={{
+              marginTop: 8,
+              padding: "8px 12px",
+              background: "#050505",
+              border: "1px solid #111",
+              color: "#555",
+              fontSize: 10,
+              lineHeight: 1.7,
+              overflowX: "auto",
+            }}
+          >
+            {JSON.stringify(error.context, null, 2)}
+          </pre>
+        </details>
+      )}
+
+      {/* Actions */}
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button
+          onClick={reset}
+          style={{
+            flex: 1,
+            padding: "9px 0",
+            background: "transparent",
+            border: "1px solid rgba(0,255,178,0.3)",
+            color: "#00FFB2",
+            fontSize: 10,
+            letterSpacing: "0.12em",
+            cursor: "pointer",
+            fontFamily: "DM Mono, monospace",
+            transition: "all 0.15s",
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background =
+              "rgba(0,255,178,0.08)";
+            (e.currentTarget as HTMLButtonElement).style.borderColor =
+              "#00FFB2";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background =
+              "transparent";
+            (e.currentTarget as HTMLButtonElement).style.borderColor =
+              "rgba(0,255,178,0.3)";
+          }}
+        >
+          RETRY
+        </button>
+        <button
+          onClick={() => window.location.reload()}
+          style={{
+            flex: 1,
+            padding: "9px 0",
+            background: "transparent",
+            border: "1px solid #1f1f1f",
+            color: "#555",
+            fontSize: 10,
+            letterSpacing: "0.12em",
+            cursor: "pointer",
+            fontFamily: "DM Mono, monospace",
+            transition: "all 0.15s",
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.color = "#888";
+            (e.currentTarget as HTMLButtonElement).style.borderColor = "#333";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.color = "#555";
+            (e.currentTarget as HTMLButtonElement).style.borderColor =
+              "#1f1f1f";
+          }}
+        >
+          RELOAD
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Error Boundary Class ─────────────────────────────────────────────────────
+
+export class AnchorErrorBoundary extends Component<
+  AnchorErrorBoundaryProps,
+  State
+> {
+  constructor(props: AnchorErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(raw: unknown): State {
+    return { hasError: true, error: normaliseError(raw) };
+  }
+
+  componentDidCatch(raw: unknown, errorInfo: React.ErrorInfo): void {
+    const error = normaliseError(raw);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  reset(): void {
+    this.setState({ hasError: false, error: null });
+  }
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children, fallback, componentLabel } = this.props;
+
+    if (!hasError || !error) return children;
+
+    if (fallback) return fallback(error, this.reset);
+
+    return (
+      <DefaultFallback
+        error={error}
+        reset={this.reset}
+        label={componentLabel}
+      />
+    );
+  }
+}
+
+// ─── Convenience HOC ─────────────────────────────────────────────────────────
+
+/**
+ * Wraps any component in an AnchorErrorBoundary.
+ *
+ * @example
+ * const SafeAnchorFeed = withAnchorErrorBoundary(AnchorFeed, { componentLabel: "Anchor Feed" });
+ */
+export function withAnchorErrorBoundary<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  boundaryProps?: Omit<AnchorErrorBoundaryProps, "children">,
+): React.FC<P> {
+  const displayName =
+    WrappedComponent.displayName ?? WrappedComponent.name ?? "Component";
+
+  const WrappedWithBoundary: React.FC<P> = (props) => (
+    <AnchorErrorBoundary componentLabel={displayName} {...boundaryProps}>
+      <WrappedComponent {...props} />
+    </AnchorErrorBoundary>
+  );
+
+  WrappedWithBoundary.displayName = `withAnchorErrorBoundary(${displayName})`;
+  return WrappedWithBoundary;
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+export default AnchorErrorBoundary;


### PR DESCRIPTION
 feat(sdk): AnchorErrorBoundary — Error Boundary Wrapper for SDK Components

**Repo:** `Haroldwonder/AnchorKit`

Adds a production-grade React Error Boundary that isolates failed anchor SDK responses so they never propagate and crash the host UI.

Closes #93 
---

## What's Changed

### `AnchorErrorBoundary` (class component)
- Catches all errors thrown by child SDK components via `getDerivedStateFromError` + `componentDidCatch`
- Normalises any thrown value (native `Error`, AnchorKit error shape, or raw string) into a consistent `AnchorKitError` type
- Exposes an `onError` callback for upstream logging / analytics integration
- Supports a custom `fallback` render prop for full UI control, with an opinionated `DefaultFallback` used when none is provided

### `DefaultFallback` (built-in fallback UI)
- Surfaces error code + message without leaking raw stack traces to end users
- Expandable context panel for structured SDK error metadata
- **Retry** button calls `reset()` to remount the failed subtree
- **Reload** button for hard-recovery

### `withAnchorErrorBoundary` (HOC)
- Zero-boilerplate way to wrap any existing SDK component
- Preserves `displayName` for DevTools legibility

---

## Usage

```tsx
// Declarative

  


// HOC
const SafeFeed = withAnchorErrorBoundary(AnchorFeed, { componentLabel: "Anchor Feed" });

// Custom fallback
<AnchorErrorBoundary fallback={(err, reset) => }>
  

```

---

## Files

| File | Description |
|---|---|
| `AnchorErrorBoundary.tsx` | Boundary class, default fallback UI, HOC, and shared types |

## Checklist

- [x] Failed anchor responses caught — UI does not crash
- [x] Error fallback component implemented
- [x] Retry / reset handler exposed
- [x] `onError` hook for external logging
- [x] `withAnchorErrorBoundary` HOC for drop-in wrapping
- [x] Typed with `AnchorKitError` interface