### PR TITLE
feat: add SDK Configuration Manager

### DIFF
--- a/NORMALIZATION_QUICK_REF.md
+++ b/NORMALIZATION_QUICK_REF.md
@@ -1,0 +1,75 @@
+# Response Normalization - Quick Reference
+
+## Core Structure
+
+```rust
+pub struct NormalizedResponse {
+    pub status: String,
+    pub amount: u64,
+    pub asset: String,
+    pub fee: u64,
+    pub id: String,
+}
+```
+
+## Contract Methods
+
+```rust
+// Normalize deposit
+normalize_deposit_response(
+    env: Env,
+    response: DepositResponse,
+    amount: u64,
+    asset: String,
+    fee: u64,
+) -> Result<NormalizedResponse, Error>
+
+// Normalize withdrawal
+normalize_withdraw_response(
+    env: Env,
+    response: WithdrawResponse,
+    amount: u64,
+    asset: String,
+    fee: u64,
+) -> Result<NormalizedResponse, Error>
+
+// Normalize quote
+normalize_quote_response(
+    env: Env,
+    anchor: Address,
+    quote_id: u64,
+    amount: u64,
+    id_prefix: String,
+) -> Result<NormalizedResponse, Error>
+```
+
+## Example
+
+```rust
+// Different anchors return different structures:
+// Anchor A: { tx_id, state, ... }
+// Anchor B: { transaction_id, status, ... }
+// Anchor C: { id, processing_status, ... }
+
+// All normalize to:
+{
+    status: "pending",
+    amount: 100_0000000,
+    asset: "USDC",
+    fee: 1_0000000,
+    id: "tx_123"
+}
+```
+
+## Error Handling
+
+- `ProtocolInvalidPayload` - Empty status or id
+- `UnsupportedAsset` - Empty asset
+- `InvalidQuote` - Quote not found
+
+## Testing
+
+Run tests:
+```bash
+cargo test --lib response_normalizer
+```

--- a/src/anchor_info_discovery.rs
+++ b/src/anchor_info_discovery.rs
@@ -373,7 +373,7 @@ mod tests {
 
             let usdc = String::from_str(&env, "USDC");
             let asset = AnchorInfoDiscovery::get_asset_info(&env, &anchor, &usdc).unwrap();
-            
+
             assert_eq!(asset.code, usdc);
             assert_eq!(asset.issuer, String::from_str(&env, "GABC123"));
             assert!(asset.deposit_enabled);
@@ -411,7 +411,7 @@ mod tests {
 
             let usdc = String::from_str(&env, "USDC");
             let (min, max) = AnchorInfoDiscovery::get_deposit_limits(&env, &anchor, &usdc).unwrap();
-            
+
             assert_eq!(min, 1000);
             assert_eq!(max, 1000000);
         });
@@ -429,8 +429,9 @@ mod tests {
             AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
             let usdc = String::from_str(&env, "USDC");
-            let (min, max) = AnchorInfoDiscovery::get_withdrawal_limits(&env, &anchor, &usdc).unwrap();
-            
+            let (min, max) =
+                AnchorInfoDiscovery::get_withdrawal_limits(&env, &anchor, &usdc).unwrap();
+
             assert_eq!(min, 500);
             assert_eq!(max, 500000);
         });
@@ -448,8 +449,9 @@ mod tests {
             AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
             let usdc = String::from_str(&env, "USDC");
-            let (fixed, percent) = AnchorInfoDiscovery::get_deposit_fees(&env, &anchor, &usdc).unwrap();
-            
+            let (fixed, percent) =
+                AnchorInfoDiscovery::get_deposit_fees(&env, &anchor, &usdc).unwrap();
+
             assert_eq!(fixed, 100);
             assert_eq!(percent, 10);
         });
@@ -467,8 +469,9 @@ mod tests {
             AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
             let usdc = String::from_str(&env, "USDC");
-            let (fixed, percent) = AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
-            
+            let (fixed, percent) =
+                AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
+
             assert_eq!(fixed, 50);
             assert_eq!(percent, 5);
         });

--- a/src/anchor_info_discovery_tests.rs
+++ b/src/anchor_info_discovery_tests.rs
@@ -1,6 +1,9 @@
 use crate::anchor_info_discovery::{AnchorInfoDiscovery, AssetInfo, StellarToml};
 use crate::errors::Error;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String, Vec,
+};
 
 fn setup_test_env(env: &Env) -> Address {
     let contract_id = env.register_contract(None, crate::AnchorKitContract);
@@ -206,7 +209,8 @@ fn test_get_withdrawal_fees() {
         AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
         let usdc = String::from_str(&env, "USDC");
-        let (fixed, percent) = AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
+        let (fixed, percent) =
+            AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
 
         assert_eq!(fixed, 50);
         assert_eq!(percent, 5);
@@ -285,10 +289,7 @@ fn test_multiple_assets() {
 
         assert_eq!(usdc_info.code, usdc);
         assert_eq!(xlm_info.code, xlm);
-        assert_ne!(
-            usdc_info.deposit_fee_fixed,
-            xlm_info.deposit_fee_fixed
-        );
+        assert_ne!(usdc_info.deposit_fee_fixed, xlm_info.deposit_fee_fixed);
     });
 }
 
@@ -375,8 +376,10 @@ fn test_asset_limits_validation() {
         AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
         let usdc = String::from_str(&env, "USDC");
-        let (dep_min, dep_max) = AnchorInfoDiscovery::get_deposit_limits(&env, &anchor, &usdc).unwrap();
-        let (with_min, with_max) = AnchorInfoDiscovery::get_withdrawal_limits(&env, &anchor, &usdc).unwrap();
+        let (dep_min, dep_max) =
+            AnchorInfoDiscovery::get_deposit_limits(&env, &anchor, &usdc).unwrap();
+        let (with_min, with_max) =
+            AnchorInfoDiscovery::get_withdrawal_limits(&env, &anchor, &usdc).unwrap();
 
         assert!(dep_min < dep_max);
         assert!(with_min < with_max);
@@ -395,8 +398,10 @@ fn test_fee_structure() {
         AnchorInfoDiscovery::fetch_and_cache(&env, &anchor, domain, None).unwrap();
 
         let usdc = String::from_str(&env, "USDC");
-        let (dep_fixed, dep_percent) = AnchorInfoDiscovery::get_deposit_fees(&env, &anchor, &usdc).unwrap();
-        let (with_fixed, with_percent) = AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
+        let (dep_fixed, dep_percent) =
+            AnchorInfoDiscovery::get_deposit_fees(&env, &anchor, &usdc).unwrap();
+        let (with_fixed, with_percent) =
+            AnchorInfoDiscovery::get_withdrawal_fees(&env, &anchor, &usdc).unwrap();
 
         assert!(dep_fixed > 0);
         assert!(dep_percent > 0);

--- a/src/anchor_kit_error.rs
+++ b/src/anchor_kit_error.rs
@@ -1,17 +1,16 @@
+use crate::error_mapping::{
+    get_error_category, get_error_severity, is_protocol_error, is_protocol_error_retryable,
+    is_transport_error, is_transport_error_retryable,
+};
 /// AnchorKitError: Custom error class with standardized error codes and consistent response format
-/// 
+///
 /// This module provides a comprehensive error handling system for AnchorKit that:
 /// 1. Wraps the base Error enum with additional context and metadata
 /// 2. Provides standardized error codes with semantic meaning
 /// 3. Ensures consistent response formatting across all operations
 /// 4. Enables rich error context for debugging and logging
 /// 5. Supports error classification and recovery strategies
-
 use crate::errors::Error;
-use crate::error_mapping::{
-    get_error_category, get_error_severity, is_protocol_error, is_protocol_error_retryable,
-    is_transport_error, is_transport_error_retryable,
-};
 
 /// Standardized error codes with semantic meaning
 /// These codes are stable and can be used for API contracts
@@ -88,6 +87,13 @@ pub enum ErrorCode {
     // Asset Validation (2600-2699)
     AssetNotConfigured = 2601,
     UnsupportedAsset = 2602,
+
+    // Webhook Middleware (2700-2799)
+    WebhookTimestampExpired = 2701,
+    WebhookTimestampInFuture = 2702,
+    WebhookPayloadTooLarge = 2703,
+    WebhookSignatureInvalid = 2704,
+    WebhookValidationFailed = 2705,
 }
 
 impl ErrorCode {
@@ -131,6 +137,11 @@ impl ErrorCode {
             Error::RateLimitExceeded => ErrorCode::RateLimitExceeded,
             Error::AssetNotConfigured => ErrorCode::AssetNotConfigured,
             Error::UnsupportedAsset => ErrorCode::UnsupportedAsset,
+            Error::WebhookTimestampExpired => ErrorCode::WebhookTimestampExpired,
+            Error::WebhookTimestampInFuture => ErrorCode::WebhookTimestampInFuture,
+            Error::WebhookPayloadTooLarge => ErrorCode::WebhookPayloadTooLarge,
+            Error::WebhookSignatureInvalid => ErrorCode::WebhookSignatureInvalid,
+            Error::WebhookValidationFailed => ErrorCode::WebhookValidationFailed,
         }
     }
 
@@ -174,6 +185,11 @@ impl ErrorCode {
             ErrorCode::RateLimitExceeded => "RateLimitExceeded",
             ErrorCode::AssetNotConfigured => "AssetNotConfigured",
             ErrorCode::UnsupportedAsset => "UnsupportedAsset",
+            ErrorCode::WebhookTimestampExpired => "WebhookTimestampExpired",
+            ErrorCode::WebhookTimestampInFuture => "WebhookTimestampInFuture",
+            ErrorCode::WebhookPayloadTooLarge => "WebhookPayloadTooLarge",
+            ErrorCode::WebhookSignatureInvalid => "WebhookSignatureInvalid",
+            ErrorCode::WebhookValidationFailed => "WebhookValidationFailed",
         }
     }
 
@@ -264,6 +280,11 @@ impl ErrorCode {
             ErrorCode::RateLimitExceeded => Error::RateLimitExceeded,
             ErrorCode::AssetNotConfigured => Error::AssetNotConfigured,
             ErrorCode::UnsupportedAsset => Error::UnsupportedAsset,
+            ErrorCode::WebhookTimestampExpired => Error::WebhookTimestampExpired,
+            ErrorCode::WebhookTimestampInFuture => Error::WebhookTimestampInFuture,
+            ErrorCode::WebhookPayloadTooLarge => Error::WebhookPayloadTooLarge,
+            ErrorCode::WebhookSignatureInvalid => Error::WebhookSignatureInvalid,
+            ErrorCode::WebhookValidationFailed => Error::WebhookValidationFailed,
         }
     }
 }

--- a/src/interactive_support.rs
+++ b/src/interactive_support.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env, String, Map};
+use soroban_sdk::{contracttype, Address, Env, Map, String};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -27,7 +27,12 @@ pub struct TransactionStatus {
 pub struct InteractiveSupport;
 
 impl InteractiveSupport {
-    pub fn generate_url(env: &Env, _anchor: &Address, _token: &String, tx_id: &String) -> InteractiveUrl {
+    pub fn generate_url(
+        env: &Env,
+        _anchor: &Address,
+        _token: &String,
+        tx_id: &String,
+    ) -> InteractiveUrl {
         InteractiveUrl {
             url: String::from_str(env, "https://anchor.example.com/interactive"),
             transaction_id: tx_id.clone(),
@@ -37,8 +42,10 @@ impl InteractiveSupport {
 
     pub fn inject_token(env: &Env, _token: &String) -> Map<String, String> {
         let mut headers = Map::new(env);
-        headers.set(String::from_str(env, "Authorization"), 
-                   String::from_str(env, "Bearer token"));
+        headers.set(
+            String::from_str(env, "Authorization"),
+            String::from_str(env, "Bearer token"),
+        );
         headers
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,14 @@ mod credentials;
 mod error_mapping;
 mod errors;
 mod events;
+mod interactive_support;
 mod metadata_cache;
 mod rate_limiter;
 mod request_history;
 mod request_id;
 mod response_normalizer;
 mod retry;
+mod sdk_config;
 mod sep10_auth;
 mod sep24_adapter;
 mod serialization;
@@ -86,6 +88,9 @@ mod request_id_tests;
 mod request_history_tests;
 
 #[cfg(test)]
+mod sdk_config_tests;
+
+#[cfg(test)]
 mod tracing_span_tests;
 
 #[cfg(test)]
@@ -95,21 +100,23 @@ mod anchor_info_discovery_tests;
 #[cfg(test)]
 mod webhook_middleware_tests;
 
-
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Vec};
 
+pub use anchor_kit_error::{
+    AnchorKitError, ErrorCategory, ErrorCode, ErrorResponse, ErrorSeverity,
+};
 pub use asset_validator::{AssetConfig, AssetValidator};
 pub use config::{AttestorConfig, ContractConfig, SessionConfig};
 pub use connection_pool::{ConnectionPool, ConnectionPoolConfig, ConnectionStats};
 pub use credentials::{CredentialManager, CredentialPolicy, CredentialType, SecureCredential};
-pub use anchor_kit_error::{
-    AnchorKitError, ErrorCategory, ErrorCode, ErrorResponse, ErrorSeverity,
-};
 pub use errors::Error;
 pub use events::{
     AttestationRecorded, AttestorAdded, AttestorRemoved, EndpointConfigured, EndpointRemoved,
     OperationLogged, QuoteReceived, QuoteSubmitted, ServicesConfigured, SessionCreated,
     SettlementConfirmed, TransferInitiated,
+};
+pub use interactive_support::{
+    CallbackData, InteractiveSupport, InteractiveUrl, TransactionStatus,
 };
 pub use metadata_cache::{CachedCapabilities, CachedMetadata, MetadataCache};
 pub use rate_limiter::{RateLimitConfig, RateLimiter};
@@ -1985,19 +1992,12 @@ impl AnchorKitContract {
     }
 
     /// Handle callback from anchor
-    pub fn handle_anchor_callback(
-        env: Env,
-        tx_id: String,
-        status: String,
-    ) -> CallbackData {
+    pub fn handle_anchor_callback(env: Env, tx_id: String, status: String) -> CallbackData {
         InteractiveSupport::handle_callback(&env, &tx_id, &status)
     }
 
     /// Poll transaction status
-    pub fn poll_transaction_status(
-        env: Env,
-        tx_id: String,
-    ) -> TransactionStatus {
+    pub fn poll_transaction_status(env: Env, tx_id: String) -> TransactionStatus {
         InteractiveSupport::poll_status(&env, &tx_id)
     }
 
@@ -2086,10 +2086,7 @@ impl AnchorKitContract {
     }
 
     /// Store SEP-10 session securely
-    pub fn sep10_store_session(
-        env: Env,
-        session: sep10_auth::Sep10Session,
-    ) -> Result<(), Error> {
+    pub fn sep10_store_session(env: Env, session: sep10_auth::Sep10Session) -> Result<(), Error> {
         if !Storage::is_attestor(&env, &session.anchor) {
             return Err(Error::AttestorNotRegistered);
         }
@@ -2098,10 +2095,7 @@ impl AnchorKitContract {
     }
 
     /// Get stored SEP-10 session
-    pub fn sep10_get_session(
-        env: Env,
-        anchor: Address,
-    ) -> Option<sep10_auth::Sep10Session> {
+    pub fn sep10_get_session(env: Env, anchor: Address) -> Option<sep10_auth::Sep10Session> {
         sep10_auth::get_session(&env, anchor)
     }
 
@@ -2117,11 +2111,18 @@ impl AnchorKitContract {
         if !Storage::is_attestor(&env, &anchor) {
             return Err(Error::AttestorNotRegistered);
         }
-        sep10_auth::authenticate(&env, anchor, client_account, signature, public_key, home_domain)
-            .map_err(|code| match code {
-                401 => Error::TransportUnauthorized,
-                403 => Error::ComplianceNotMet,
-                _ => Error::TransportError,
-            })
+        sep10_auth::authenticate(
+            &env,
+            anchor,
+            client_account,
+            signature,
+            public_key,
+            home_domain,
+        )
+        .map_err(|code| match code {
+            401 => Error::TransportUnauthorized,
+            403 => Error::ComplianceNotMet,
+            _ => Error::TransportError,
+        })
     }
 }

--- a/src/response_normalizer.rs
+++ b/src/response_normalizer.rs
@@ -165,13 +165,16 @@ mod tests {
         assert_eq!(normalized.status, String::from_str(&env, "quoted"));
         assert_eq!(normalized.amount, 100_0000000);
         assert_eq!(normalized.asset, String::from_str(&env, "USDC"));
-        assert_eq!(normalized.fee, 500000);
+        assert_eq!(normalized.fee, 5000000); // 50 basis points = 0.5% of 1000000000
         assert_eq!(normalized.id, String::from_str(&env, "quote_789"));
     }
 
     #[test]
     fn test_calculate_fee() {
-        assert_eq!(ResponseNormalizer::calculate_fee(100_0000000, 50), 500000);
+        // fee_percentage is in basis points (1/10000)
+        // 50 basis points = 0.5%
+        assert_eq!(ResponseNormalizer::calculate_fee(100_0000000, 50), 5000000);
+        // 100 basis points = 1%
         assert_eq!(
             ResponseNormalizer::calculate_fee(100_0000000, 100),
             1_0000000

--- a/src/sdk_config.rs
+++ b/src/sdk_config.rs
@@ -1,0 +1,64 @@
+use soroban_sdk::{contracttype, String};
+
+use crate::errors::Error;
+
+/// Network type for SDK operations
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Network {
+    Testnet,
+    Mainnet,
+}
+
+/// SDK configuration for anchor operations
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SdkConfig {
+    pub network: Network,
+    pub timeout_seconds: u32,
+    pub retry_attempts: u32,
+    pub default_anchor: String,
+}
+
+// Validation constants
+const MIN_TIMEOUT: u32 = 5;
+const MAX_TIMEOUT: u32 = 300;
+const MIN_RETRY: u32 = 0;
+const MAX_RETRY: u32 = 10;
+const MIN_ANCHOR_LEN: u32 = 3;
+const MAX_ANCHOR_LEN: u32 = 256;
+
+impl SdkConfig {
+    pub fn new(
+        network: Network,
+        timeout_seconds: u32,
+        retry_attempts: u32,
+        default_anchor: String,
+    ) -> Result<Self, Error> {
+        let config = Self {
+            network,
+            timeout_seconds,
+            retry_attempts,
+            default_anchor,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.timeout_seconds < MIN_TIMEOUT || self.timeout_seconds > MAX_TIMEOUT {
+            return Err(Error::InvalidConfig);
+        }
+
+        if self.retry_attempts > MAX_RETRY {
+            return Err(Error::InvalidConfig);
+        }
+
+        let anchor_len = self.default_anchor.len();
+        if anchor_len < MIN_ANCHOR_LEN || anchor_len > MAX_ANCHOR_LEN {
+            return Err(Error::InvalidConfig);
+        }
+
+        Ok(())
+    }
+}

--- a/src/sdk_config_tests.rs
+++ b/src/sdk_config_tests.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use crate::sdk_config::{Network, SdkConfig};
+    use soroban_sdk::{Env, String};
+
+    #[test]
+    fn test_valid_testnet_config() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            30,
+            3,
+            String::from_str(&env, "testanchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_valid_mainnet_config() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Mainnet,
+            60,
+            5,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_timeout_too_low() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            2,
+            3,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_timeout_too_high() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            400,
+            3,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_retry_too_high() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            30,
+            15,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_anchor_too_short() {
+        let env = Env::default();
+        let config = SdkConfig::new(Network::Testnet, 30, 3, String::from_str(&env, "ab"));
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_min_retry_zero() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            30,
+            0,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_max_retry_ten() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Mainnet,
+            30,
+            10,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_min_timeout_five() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Testnet,
+            5,
+            3,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_max_timeout_300() {
+        let env = Env::default();
+        let config = SdkConfig::new(
+            Network::Mainnet,
+            300,
+            3,
+            String::from_str(&env, "anchor.stellar.org"),
+        );
+        assert!(config.is_ok());
+    }
+}

--- a/src/sep10_auth.rs
+++ b/src/sep10_auth.rs
@@ -49,7 +49,10 @@ pub fn validate_home_domain(env: &Env, anchor: Address, home_domain: String) -> 
 
 /// Store JWT session securely
 pub fn store_session(env: &Env, session: Sep10Session) {
-    let key = (soroban_sdk::symbol_short!("SESSION"), session.anchor.clone());
+    let key = (
+        soroban_sdk::symbol_short!("SESSION"),
+        session.anchor.clone(),
+    );
     env.storage().persistent().set(&key, &session);
     env.storage().persistent().extend_ttl(&key, 86400, 86400);
 }
@@ -71,17 +74,17 @@ pub fn authenticate(
 ) -> Result<Sep10Session, u32> {
     // 1. Fetch challenge
     let challenge = fetch_challenge(env, anchor.clone(), client_account);
-    
+
     // 2. Verify signature
     if !verify_signature(env, &challenge, signature, public_key) {
         return Err(401);
     }
-    
+
     // 3. Validate home domain
     if !validate_home_domain(env, anchor.clone(), home_domain.clone()) {
         return Err(403);
     }
-    
+
     // 4. Create and store session
     let session = Sep10Session {
         jwt: String::from_str(env, "jwt_token"),
@@ -89,8 +92,8 @@ pub fn authenticate(
         expires_at: env.ledger().timestamp() + 3600,
         home_domain,
     };
-    
+
     store_session(env, session.clone());
-    
+
     Ok(session)
 }

--- a/src/tracing_span_tests.rs
+++ b/src/tracing_span_tests.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tracing_span_tests {
     use crate::{AnchorKitContract, AnchorKitContractClient};
-    use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Bytes, BytesN, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Bytes, BytesN, Env,
+    };
 
     #[test]
     fn test_span_emits_request_id() {
@@ -66,8 +69,7 @@ mod tracing_span_tests {
 
         let span = client.get_tracing_span(&request_id.id).unwrap();
         assert_eq!(span.actor, attestor);
-        // Timestamp may be 0 in test environment, just verify it's set
-        assert!(span.started_at >= 0);
+        // Timestamp is always >= 0 for u64, just verify completed_at is after started_at
         assert!(span.completed_at >= span.started_at);
     }
 

--- a/src/webhook_middleware_tests.rs
+++ b/src/webhook_middleware_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod webhook_middleware_tests {
     use crate::webhook_middleware::*;
-    use soroban_sdk::{testutils::*, Address, Bytes, BytesN, Env, String};
     use alloc::vec;
+    use soroban_sdk::{testutils::*, Address, Bytes, BytesN, Env, String};
 
     fn create_test_env() -> Env {
         Env::default()
@@ -31,7 +31,7 @@ mod webhook_middleware_tests {
         } else {
             Bytes::new(env)
         };
-        
+
         WebhookRequest {
             payload: payload_bytes,
             signature: Bytes::from_array(env, &[0u8; 32]),


### PR DESCRIPTION
Closes #136

---

- Add Network enum (Testnet/Mainnet)
- Add SdkConfig with timeout, retry, and default anchor
- Implement validation with sensible constraints
- Add 10 comprehensive tests (all passing)

Additional fixes:
- Fix response_normalizer fee calculation bug
- Fix clippy errors in tracing_span_tests
- Add missing webhook error codes to anchor_kit_error
- Add interactive_support module exports