### PR TITLE
feat: add StorageCorrupted error and update validation logic in contract

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -317,6 +317,9 @@ impl AnchorKitContract {
 
     pub fn initialize(env: Env, admin: Address) {
         admin.require_auth();
+        if admin == env.current_contract_address() {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
         let inst = env.storage().instance();
         if inst.has(&admin_key(&env)) {
             panic_with_error!(&env, ErrorCode::AlreadyInitialized);
@@ -724,7 +727,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
 
         // Convert stored Bytes payload_hash to BytesN<32>
         let stored: BytesN<32> = attestation.payload_hash.try_into().unwrap_or_else(|_| {
-            panic_with_error!(&env, ErrorCode::ValidationError)
+            panic_with_error!(&env, ErrorCode::StorageCorrupted)
         });
         verify_payload_hash(&stored, &expected_hash)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,9 +42,10 @@ pub enum ErrorCode {
     ServicesNotConfigured = 14,
     ValidationError = 15,
     RateLimitExceeded = 16,
-    NotInitialized = 16,
-    AttestationNotFound = 17,
-    InvalidSep10Token = 18,
+    NotInitialized = 17,
+    AttestationNotFound = 18,
+    InvalidSep10Token = 19,
+    StorageCorrupted = 20,
     CacheExpired = 48,
     CacheNotFound = 49,
 }
@@ -72,6 +73,7 @@ impl ErrorCode {
             ErrorCode::NotInitialized => "Contract is not initialized",
             ErrorCode::AttestationNotFound => "Attestation not found",
             ErrorCode::InvalidSep10Token => "SEP-10 JWT is missing, expired, or invalid",
+            ErrorCode::StorageCorrupted => "On-chain storage entry is corrupted or unreadable",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
         }
@@ -199,6 +201,10 @@ impl AnchorKitError {
     pub fn rate_limit_exceeded() -> Self {
         Self::from_code(ErrorCode::RateLimitExceeded)
     }
+
+    pub fn storage_corrupted() -> Self {
+        Self::from_code(ErrorCode::StorageCorrupted)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +298,7 @@ mod tests {
             ErrorCode::NotInitialized,
             ErrorCode::AttestationNotFound,
             ErrorCode::InvalidSep10Token,
+            ErrorCode::StorageCorrupted,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use sep6::{
     RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, TransactionKind,
     TransactionStatus, TransactionStatusResponse, WithdrawalResponse,
 };
-pub use contract::{AnchorKitContract, EndpointUpdated, get_endpoint, set_endpoint};
+pub use contract::{AnchorKitContract, EndpointUpdated, get_admin, get_endpoint, set_endpoint};
 
 #[cfg(test)]
 mod request_id_tests;


### PR DESCRIPTION
 Fix duplicate ErrorCode discriminant: RateLimitExceeded and NotInitialized both use value 16
Fixes #208

Add `ErrorCode::StorageCorrupted` for on-chain storage read failures Fixes #209

contract.rs: `initialize` does not validate that admin address is non-zero Fixes #210

Expose `get_admin` as a public contract function for off-chain tooling Fixes #211
