### PR TITLE
fix: auto-deactivate anchors on consecutive health check failures

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -287,6 +287,23 @@ pub struct EndpointUpdated {
     pub endpoint: String,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub struct HealthStatus {
+    pub anchor: Address,
+    pub latency_ms: u64,
+    pub failure_count: u32,
+    pub availability_percent: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct AnchorDeactivated {
+    anchor: Address,
+    failure_count: u32,
+    threshold: u32,
+}
+
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
 // ---------------------------------------------------------------------------
@@ -1124,6 +1141,74 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         Self::require_admin(&env);
         let key = (symbol_short!("CAPCACHE"), anchor);
         env.storage().temporary().remove(&key);
+    }
+
+    // -----------------------------------------------------------------------
+    // Health monitoring
+    // -----------------------------------------------------------------------
+
+    /// Set the consecutive-failure threshold after which an anchor is auto-deactivated.
+    /// Admin-only. Default is 0 (feature disabled).
+    pub fn set_health_failure_threshold(env: Env, threshold: u32) {
+        Self::require_admin(&env);
+        env.storage().instance().set(&symbol_short!("HTHRESH"), &threshold);
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+    }
+
+    /// Record a health check result for `anchor`.
+    /// `failure_count` is the current consecutive failure count (caller-supplied).
+    /// If `failure_count` >= configured threshold (and threshold > 0), sets `is_active = false`
+    /// on the anchor's routing metadata and emits `AnchorDeactivated`.
+    pub fn update_health_status(
+        env: Env,
+        anchor: Address,
+        latency_ms: u64,
+        failure_count: u32,
+        availability_percent: u32,
+    ) {
+        let status = HealthStatus {
+            anchor: anchor.clone(),
+            latency_ms,
+            failure_count,
+            availability_percent,
+        };
+        let key = (symbol_short!("HEALTH"), anchor.clone());
+        env.storage().persistent().set(&key, &status);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("HTHRESH"))
+            .unwrap_or(0u32);
+
+        if threshold > 0 && failure_count >= threshold {
+            let meta_key = (symbol_short!("ANCHMETA"), anchor.clone());
+            if let Some(mut meta) = env
+                .storage()
+                .persistent()
+                .get::<_, RoutingAnchorMeta>(&meta_key)
+            {
+                if meta.is_active {
+                    meta.is_active = false;
+                    env.storage().persistent().set(&meta_key, &meta);
+                    env.storage()
+                        .persistent()
+                        .extend_ttl(&meta_key, PERSISTENT_TTL, PERSISTENT_TTL);
+                    env.events().publish(
+                        (symbol_short!("anchor"), symbol_short!("deactivate")),
+                        AnchorDeactivated { anchor, failure_count, threshold },
+                    );
+                }
+            }
+        }
+    }
+
+    /// Retrieve the last recorded health status for `anchor`, or `None` if not set.
+    pub fn get_health_status(env: Env, anchor: Address) -> Option<HealthStatus> {
+        env.storage()
+            .persistent()
+            .get::<_, HealthStatus>(&(symbol_short!("HEALTH"), anchor))
     }
 
     // -----------------------------------------------------------------------

--- a/src/routing_tests.rs
+++ b/src/routing_tests.rs
@@ -331,4 +331,49 @@ mod routing_tests {
         assert_eq!(best.anchor, anchor2);
         assert_eq!(best.fee_percentage, 25);
     }
+
+    #[test]
+    fn test_auto_deactivation() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+        client.set_anchor_metadata(&anchor, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+        client.submit_quote(
+            &anchor,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &20u32, &100u64, &100000u64, &1_003_600u64,
+        );
+
+        // Set threshold to 3 consecutive failures
+        client.set_health_failure_threshold(&3u32);
+
+        // Two failures — below threshold, anchor still active
+        client.update_health_status(&anchor, &100u64, &2u32, &9800u32);
+        let mut strategy = Vec::new(&env);
+        strategy.push_back(Symbol::new(&env, "LowestFee"));
+        let options = RoutingOptions {
+            request: make_request(&env),
+            strategy: strategy.clone(),
+            min_reputation: 0,
+            max_anchors: 1,
+            require_kyc: false,
+        };
+        let best = client.route_transaction(&options);
+        assert_eq!(best.anchor, anchor);
+
+        // Third failure — threshold breached, anchor deactivated
+        client.update_health_status(&anchor, &100u64, &3u32, &9500u32);
+
+        // Health status recorded
+        let health = client.get_health_status(&anchor).unwrap();
+        assert_eq!(health.failure_count, 3);
+
+        // Anchor no longer routable
+        let result = client.try_route_transaction(&options);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Closes #244

---

## Problem

`is_active` on `RoutingAnchorMeta` was set to `true` at registration time and never updated, so anchors that were failing health checks continued to receive routing.

## Changes

- **`HealthStatus` struct** — persists `latency_ms`, `failure_count`, `availability_percent` per anchor
- **`AnchorDeactivated` event** — emitted with `anchor`, `failure_count`, and `threshold` on deactivation
- **`set_health_failure_threshold(threshold)`** — admin-only; configures consecutive-failure threshold (default `0` = disabled, backward-compatible)
- **`update_health_status(...)`** — records health check result; flips `is_active = false` and emits `AnchorDeactivated` when `failure_count >= threshold > 0`
- **`get_health_status(anchor)`** — returns last recorded `HealthStatus`

## Tests

`test_auto_deactivation`: sets threshold=3, confirms anchor routes at 2 failures, confirms anchor is excluded from routing and deactivated at 3 failures.

## Acceptance Criteria

- [x] Health check failure threshold configurable
- [x] `is_active` updated on threshold breach
- [x] `AnchorDeactivated` event emitted
- [x] Test for auto-deactivation