### PR TITLE
Implement Attestation Pagination Support for AnchorKit

### DIFF
--- a/src/attestation_pagination_tests.rs
+++ b/src/attestation_pagination_tests.rs
@@ -1,0 +1,203 @@
+#![cfg(test)]
+
+mod attestation_pagination_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env, Vec,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use crate::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn setup_ledger(env: &Env) {
+        env.ledger().set(LedgerInfo {
+            timestamp: 1700000000,
+            protocol_version: 21,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 100,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn payload(env: &Env, byte: u8) -> Bytes {
+        let mut b = Bytes::new(env);
+        for _ in 0..32 {
+            b.push_back(byte);
+        }
+        b
+    }
+
+    fn sig(env: &Env, byte: u8) -> Bytes {
+        let mut b = Bytes::new(env);
+        for _ in 0..64 {
+            b.push_back(byte);
+        }
+        b
+    }
+
+    #[test]
+    fn test_list_attestations_empty() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let subject = Address::generate(&env);
+        let results = client.list_attestations(&subject, &0, &10);
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_list_attestations_single_subject() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Submit 5 attestations
+        for i in 0..5 {
+            client.submit_attestation(&attestor, &subject, &(1700000000 + i as u64), &payload(&env, i), &sig(&env, i));
+        }
+
+        let results = client.list_attestations(&subject, &0, &10);
+        assert_eq!(results.len(), 5);
+        assert_eq!(results.get(0).unwrap().id, 0);
+        assert_eq!(results.get(4).unwrap().id, 4);
+    }
+
+    #[test]
+    fn test_list_attestations_pagination() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Submit 10 attestations
+        for i in 0..10 {
+            client.submit_attestation(&attestor, &subject, &(1700000000 + i as u64), &payload(&env, i), &sig(&env, i));
+        }
+
+        // Page 1: offset 0, limit 3
+        let page1 = client.list_attestations(&subject, &0, &3);
+        assert_eq!(page1.len(), 3);
+        assert_eq!(page1.get(0).unwrap().id, 0);
+        assert_eq!(page1.get(2).unwrap().id, 2);
+
+        // Page 2: offset 3, limit 3
+        let page2 = client.list_attestations(&subject, &3, &3);
+        assert_eq!(page2.len(), 3);
+        assert_eq!(page2.get(0).unwrap().id, 3);
+        assert_eq!(page2.get(2).unwrap().id, 5);
+
+        // Page 4: offset 9, limit 3 (only 1 left)
+        let page4 = client.list_attestations(&subject, &9, &3);
+        assert_eq!(page4.len(), 1);
+        assert_eq!(page4.get(0).unwrap().id, 9);
+    }
+
+    #[test]
+    fn test_list_attestations_multiple_subjects() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subj1 = Address::generate(&env);
+        let subj2 = Address::generate(&env);
+        client.initialize(&admin);
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Subj1: 2 attestations
+        client.submit_attestation(&attestor, &subj1, &1700000001, &payload(&env, 1), &sig(&env, 1));
+        client.submit_attestation(&attestor, &subj1, &1700000002, &payload(&env, 2), &sig(&env, 2));
+
+        // Subj2: 1 attestation
+        client.submit_attestation(&attestor, &subj2, &1700000003, &payload(&env, 3), &sig(&env, 3));
+
+        let res1 = client.list_attestations(&subj1, &0, &10);
+        assert_eq!(res1.len(), 2);
+        assert_eq!(res1.get(0).unwrap().id, 0);
+        assert_eq!(res1.get(1).unwrap().id, 1);
+
+        let res2 = client.list_attestations(&subj2, &0, &10);
+        assert_eq!(res2.len(), 1);
+        assert_eq!(res2.get(0).unwrap().id, 2);
+    }
+
+    #[test]
+    fn test_list_attestations_limit_capping() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Submit 60 attestations
+        for i in 0..60 {
+            client.submit_attestation(&attestor, &subject, &(1700000000 + i as u64), &payload(&env, i as u8), &sig(&env, i as u8));
+        }
+
+        // Request 100, should get only 50
+        let results = client.list_attestations(&subject, &0, &100);
+        assert_eq!(results.len(), 50);
+    }
+
+    #[test]
+    fn test_list_attestations_offset_out_of_bounds() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        client.submit_attestation(&attestor, &subject, &1700000001, &payload(&env, 1), &sig(&env, 1));
+
+        let results = client.list_attestations(&subject, &5, &10);
+        assert_eq!(results.len(), 0);
+    }
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Bytes, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
@@ -351,9 +351,10 @@ impl AnchorKitContract {
         }
 
         let hash = env.crypto().sha256(&input);
+        let hash_bytes = Bytes::from_array(&env, &hash.into());
         let mut id = Bytes::new(&env);
         for i in 0..16u32 {
-            id.push_back(hash.get(i).unwrap());
+            id.push_back(hash_bytes.get(i).unwrap());
         }
 
         RequestId { id, created_at: ts }
@@ -452,7 +453,20 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     pub fn set_endpoint(env: Env, attestor: Address, endpoint: String) {
         attestor.require_auth();
         Self::check_attestor(&env, &attestor);
-        crate::validate_anchor_domain(endpoint.as_str()).map_err(|_| panic_with_error!(&env, ErrorCode::InvalidEndpointFormat))?;
+        
+        // Convert soroban String to Rust String for validation
+        let len = endpoint.len() as usize;
+        let mut rust_buf = [0u8; 128];
+        if len > 128 {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
+        endpoint.copy_into_slice(&mut rust_buf[..len]);
+        let endpoint_str = core::str::from_utf8(&rust_buf[..len]).unwrap_or("");
+
+        if crate::validate_anchor_domain(endpoint_str).is_err() {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
+
         let key = (symbol_short!("ENDPOINT"), attestor.clone());
         env.storage().persistent().set(&key, &endpoint);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
@@ -697,6 +711,43 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             .persistent()
             .get::<_, Attestation>(&(symbol_short!("ATTEST"), id))
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound))
+    }
+
+    /// List attestations for a given subject with pagination support.
+    /// Returns up to `limit` attestations (max 50) starting from `offset`.
+    pub fn list_attestations(
+        env: Env,
+        subject: Address,
+        offset: u64,
+        limit: u32,
+    ) -> Vec<Attestation> {
+        let actual_limit = if limit > 50 { 50 } else { limit };
+        let mut results = Vec::new(&env);
+
+        let count_key = (symbol_short!("SUBCNT"), subject.clone());
+        let total_count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
+
+        if offset >= total_count || actual_limit == 0 {
+            return results;
+        }
+
+        let end = if offset + (actual_limit as u64) > total_count {
+            total_count
+        } else {
+            offset + (actual_limit as u64)
+        };
+
+        for i in offset..end {
+            let index_key = (symbol_short!("SUBATT"), subject.clone(), i);
+            if let Some(attestation_id) = env.storage().persistent().get::<_, u64>(&index_key) {
+                let main_key = (symbol_short!("ATTEST"), attestation_id);
+                if let Some(attestation) = env.storage().persistent().get::<_, Attestation>(&main_key) {
+                    results.push_back(attestation);
+                }
+            }
+        }
+
+        results
     }
 
     // -----------------------------------------------------------------------
@@ -1444,7 +1495,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         let attestation = Attestation {
             id,
             issuer,
-            subject,
+            subject: subject.clone(),
             timestamp,
             payload_hash,
             signature,
@@ -1454,6 +1505,22 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         env.storage()
             .persistent()
             .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Subject-specific index for pagination support (#215)
+        // Store only the ID to save storage space (O(1) extra space)
+        let count_key = (symbol_short!("SUBCNT"), subject.clone());
+        let count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
+
+        let subj_att_key = (symbol_short!("SUBATT"), subject.clone(), count);
+        env.storage().persistent().set(&subj_att_key, &id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&subj_att_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.storage().persistent().set(&count_key, &(count + 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&count_key, PERSISTENT_TTL, PERSISTENT_TTL);
     }
 
     fn store_span(
@@ -1478,4 +1545,12 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             .temporary()
             .extend_ttl(&key, SPAN_TTL, SPAN_TTL);
     }
+}
+
+pub fn get_endpoint(env: Env, attestor: Address) -> String {
+    AnchorKitContract::get_endpoint(env, attestor)
+}
+
+pub fn set_endpoint(env: Env, attestor: Address, endpoint: String) {
+    AnchorKitContract::set_endpoint(env, attestor, endpoint)
 }

--- a/src/deterministic_hash.rs
+++ b/src/deterministic_hash.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Bytes, BytesN, Env};
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
 
 /// Compute a canonical SHA-256 hash over attestation payload fields.
 ///
@@ -24,7 +24,7 @@ pub fn compute_payload_hash(
     // 3. data payload
     input.append(data);
 
-    env.crypto().sha256(&input)
+    env.crypto().sha256(&input).into()
 }
 
 /// Verify that the stored attestation's payload hash matches the expected hash.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,7 +42,7 @@ pub enum ErrorCode {
     ServicesNotConfigured = 14,
     ValidationError = 15,
     RateLimitExceeded = 16,
-    NotInitialized = 16,
+    NotInitialized = 101,
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
     CacheExpired = 48,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,3 +75,6 @@ mod capability_detection_tests;
 
 #[cfg(test)]
 mod attestor_endpoint_tests;
+
+#[cfg(test)]
+mod attestation_pagination_tests;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -3,7 +3,7 @@
 //! This module implements per-attestor rate limiting for attestation submissions
 //! to prevent spam and abuse of the contract.
 
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
 use crate::errors::{AnchorKitError, ErrorCode};
 
 /// Rate limit configuration stored in contract storage
@@ -27,20 +27,22 @@ pub struct RateLimitState {
 }
 
 /// Rate limiter for attestation submissions
+#[contract]
 pub struct RateLimiter;
 
+#[contractimpl]
 impl RateLimiter {
     /// Check if an attestor can submit an attestation and increment their counter
     ///
     /// Returns `Ok(())` if the attestor is within the rate limit.
     /// Returns `Err(AnchorKitError::rate_limit_exceeded())` if the limit is exceeded.
     pub fn check_and_increment(
-        env: &Env,
-        attestor: &Address,
-        config: &RateLimitConfig,
+        env: Env,
+        attestor: Address,
+        config: RateLimitConfig,
     ) -> Result<(), AnchorKitError> {
         let current_ledger = env.ledger().sequence();
-        let state_key = Self::get_state_key(env, attestor);
+        let state_key = Self::get_state_key(&env, &attestor);
         
         // Get or initialize rate limit state
         let mut state = env.storage().persistent().get::<_, RateLimitState>(&state_key)
@@ -70,8 +72,8 @@ impl RateLimiter {
     }
     
     /// Get the current rate limit state for an attestor
-    pub fn get_state(env: &Env, attestor: &Address) -> RateLimitState {
-        let state_key = Self::get_state_key(env, attestor);
+    pub fn get_state(env: Env, attestor: Address) -> RateLimitState {
+        let state_key = Self::get_state_key(&env, &attestor);
         env.storage().persistent().get::<_, RateLimitState>(&state_key)
             .unwrap_or(RateLimitState {
                 submission_count: 0,
@@ -81,20 +83,20 @@ impl RateLimiter {
     
     /// Update the rate limit configuration (admin only)
     pub fn update_config(
-        env: &Env,
-        _admin: &Address,
-        config: &RateLimitConfig,
+        env: Env,
+        _admin: Address,
+        config: RateLimitConfig,
     ) -> Result<(), AnchorKitError> {
         // In a real contract, you would check that admin is authorized
         // For now, we'll just store the config
-        let config_key = Self::get_config_key(env);
-        env.storage().persistent().set(&config_key, config);
+        let config_key = Self::get_config_key(&env);
+        env.storage().persistent().set(&config_key, &config);
         Ok(())
     }
     
     /// Get the current rate limit configuration
-    pub fn get_config(env: &Env) -> RateLimitConfig {
-        let config_key = Self::get_config_key(env);
+    pub fn get_config(env: Env) -> RateLimitConfig {
+        let config_key = Self::get_config_key(&env);
         env.storage().persistent().get::<_, RateLimitConfig>(&config_key)
             .unwrap_or(RateLimitConfig {
                 max_submissions: 10,
@@ -109,17 +111,13 @@ impl RateLimiter {
     
     /// Generate storage key for rate limit state
     fn get_state_key(env: &Env, attestor: &Address) -> soroban_sdk::BytesN<32> {
-        // Use the address bytes directly as the key
-        // Convert address to bytes using its internal representation
-        // We use the address string representation and hash it
         let address_str = attestor.to_string();
-        // Use env.crypto().sha256() to hash the address string
-        // Convert the string to bytes using copy_into_slice
-        let mut address_bytes = [0u8; 56]; // Stellar addresses are 56 characters
-        address_str.copy_into_slice(&mut address_bytes);
-        let bytes = soroban_sdk::Bytes::from_slice(env, &address_bytes);
+        let mut address_bytes = [0u8; 128]; // Buffer for address string
+        let len = address_str.len() as usize;
+        let final_len = if len > 128 { 128 } else { len };
+        address_str.copy_into_slice(&mut address_bytes[..final_len]);
+        let bytes = soroban_sdk::Bytes::from_slice(env, &address_bytes[..final_len]);
         let hash = env.crypto().sha256(&bytes);
-        // Convert Hash<32> to BytesN<32>
         hash.into()
     }
     
@@ -139,27 +137,27 @@ mod tests {
     #[test]
     fn test_rate_limit_under_limit() {
         let env = Env::default();
-        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let attestor = Address::generate(&env);
         let config = RateLimitConfig {
             max_submissions: 10,
             window_length: 100,
         };
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // Register a dummy contract for testing
         let contract_id = env.register_contract(&contract_address, crate::rate_limiter::RateLimiter);
         
         // Should succeed for first submission
         let result = env.as_contract(&contract_id, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         });
         assert!(result.is_ok());
         
         // Check state
         let state = env.as_contract(&contract_id, &|| {
-            RateLimiter::get_state(&env, &attestor)
+            RateLimiter::get_state(env.clone(), attestor.clone())
         });
         assert_eq!(state.submission_count, 1);
     }
@@ -167,26 +165,26 @@ mod tests {
     #[test]
     fn test_rate_limit_at_limit() {
         let env = Env::default();
-        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let attestor = Address::generate(&env);
         let config = RateLimitConfig {
             max_submissions: 2,
             window_length: 100,
         };
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // First two submissions should succeed
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         }).is_ok());
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         }).is_ok());
         
         // Third submission should fail
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         });
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
@@ -195,23 +193,23 @@ mod tests {
     #[test]
     fn test_rate_limit_over_limit() {
         let env = Env::default();
-        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let attestor = Address::generate(&env);
         let config = RateLimitConfig {
             max_submissions: 1,
             window_length: 100,
         };
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // First submission should succeed
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         }).is_ok());
         
         // Second submission should fail
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         });
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
@@ -220,30 +218,30 @@ mod tests {
     #[test]
     fn test_rate_limit_window_reset() {
         let env = Env::default();
-        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let attestor = Address::generate(&env);
         let config = RateLimitConfig {
             max_submissions: 1,
             window_length: 10,
         };
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // First submission should succeed
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         }).is_ok());
         
         // Second submission should fail
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(env.clone(), attestor.clone(), config.clone())
         }).is_err());
         
         // Note: In Soroban SDK, we cannot directly set the ledger sequence in tests
         // The window reset logic will be tested in integration tests with actual ledger progression
         // For now, we verify the state is correct
         let state = env.as_contract(&contract_address, &|| {
-            RateLimiter::get_state(&env, &attestor)
+            RateLimiter::get_state(env.clone(), attestor.clone())
         });
         assert_eq!(state.submission_count, 2);
     }
@@ -251,24 +249,24 @@ mod tests {
     #[test]
     fn test_rate_limit_config_update() {
         let env = Env::default();
-        let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let admin = Address::generate(&env);
         let new_config = RateLimitConfig {
             max_submissions: 20,
             window_length: 200,
         };
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // Update config
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::update_config(&env, &admin, &new_config)
+            RateLimiter::update_config(env.clone(), admin.clone(), new_config.clone())
         });
         assert!(result.is_ok());
         
         // Verify config was updated
         let config = env.as_contract(&contract_address, &|| {
-            RateLimiter::get_config(&env)
+            RateLimiter::get_config(env.clone())
         });
         assert_eq!(config.max_submissions, 20);
         assert_eq!(config.window_length, 200);
@@ -279,11 +277,11 @@ mod tests {
         let env = Env::default();
         
         // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = Address::generate(&env);
         
         // Get default config
         let config = env.as_contract(&contract_address, &|| {
-            RateLimiter::get_config(&env)
+            RateLimiter::get_config(env.clone())
         });
         assert_eq!(config.max_submissions, 10);
         assert_eq!(config.window_length, 100);

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -8,7 +8,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use soroban_sdk::{Bytes, Env, String};
+use soroban_sdk::{Bytes, BytesN, Env, String};
 
 /// Maximum JWT character length accepted by the contract (defensive bound).
 pub const MAX_JWT_LEN: u32 = 2048;
@@ -166,12 +166,10 @@ pub fn verify_sep10_jwt(
     let signing_input = Bytes::from_slice(env, &buf[..d1]);
     let sig_bytes = Bytes::from_slice(env, sig_dec.as_slice());
 
-    if !env
-        .crypto()
-        .ed25519_verify(anchor_public_key, &signing_input, &sig_bytes)
-    {
-        return Err(());
-    }
+    let pk_bytesn: BytesN<32> = anchor_public_key.clone().try_into().map_err(|_| ())?;
+    let sig_bytesn: BytesN<64> = sig_bytes.try_into().map_err(|_| ())?;
+
+    env.crypto().ed25519_verify(&pk_bytesn, &signing_input, &sig_bytesn);
 
     let payload_dec = base64url_decode(payload_b64).map_err(|_| ())?;
     let exp = parse_json_exp(&payload_dec)?;
@@ -195,6 +193,8 @@ mod tests {
     extern crate std;
 
     use super::*;
+    use alloc::format;
+    use alloc::string::ToString;
     use ed25519_dalek::{Signer, SigningKey};
     use rand::rngs::OsRng;
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};

--- a/src/sep10_test_util.rs
+++ b/src/sep10_test_util.rs
@@ -1,4 +1,6 @@
 #![cfg(test)]
+extern crate alloc;
+use alloc::format;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use ed25519_dalek::{Signer, SigningKey};
@@ -6,7 +8,7 @@ use soroban_sdk::{Address, Bytes, Env, String};
 
 use crate::contract::AnchorKitContractClient;
 
-pub fn build_sep10_jwt(signing_key: &SigningKey, sub: &str, exp: u64) -> std::string::String {
+pub fn build_sep10_jwt(signing_key: &SigningKey, sub: &str, exp: u64) -> alloc::string::String {
     let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
     let payload = format!(r#"{{"sub":"{}","exp":{}}}"#, sub, exp);
     let header_b64 = URL_SAFE_NO_PAD.encode(header);
@@ -30,9 +32,14 @@ pub fn register_attestor_with_sep10(
     client.set_sep10_jwt_verifying_key(sep10_issuer, &pk);
 
     let sub = attestor.to_string();
-    let sub_str: std::string::String = sub.to_string();
+    let mut buf = [0u8; 128];
+    let len = sub.len() as usize;
+    let final_len = if len > 128 { 128 } else { len };
+    sub.copy_into_slice(&mut buf[..final_len]);
+    let sub_str = core::str::from_utf8(&buf[..final_len]).unwrap_or("");
+    
     let exp = env.ledger().timestamp().saturating_add(86_400);
-    let jwt = build_sep10_jwt(signing_key, sub_str.as_str(), exp);
+    let jwt = build_sep10_jwt(signing_key, sub_str, exp);
     let token = String::from_str(env, jwt.as_str());
     client.register_attestor(attestor, &token, sep10_issuer);
 }


### PR DESCRIPTION
Closes #215 

### Overview:
This PR implements offset-based pagination for attestation queries as requested in issue #215. The solution utilizes a secondary index pattern to ensure high performance while strictly adhering to Soroban ledger resource constraints.

### Key Changes:
- **`list_attestations`**: Added new contract method `list_attestations(subject: Address, offset: u64, limit: u32) -> Vec<Attestation>`.
- **Secondary Indexing**: Implemented the `SUBATT` storage pattern that maps subject addresses to a list of Attestation IDs. This allows for **$O(limit)$** query time, avoiding expensive full-ledger scans.
- **Safety Constraints**: Enforced a hard limit cap of **50 items** per request to prevent resource exhaustion and high transaction fees.
- **Stability Fixes**: Resolved multiple pre-existing build errors across `RateLimiter`, `ErrorCode`, and standard SEP modules to ensure the contract is valid and testable.
- **Test Suite**: Added a dedicated test file covering:
  - Empty result handling.
  - Successful multi-page pagination.
  - Limit capping logic.
  - Out-of-bounds offset handling.