### PR TITLE
feat: add per-attestor rate limit overrides

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -30,15 +30,18 @@ pub struct RateLimitState {
 pub struct RateLimiter;
 
 impl RateLimiter {
-    /// Check if an attestor can submit an attestation and increment their counter
+    /// Check if an attestor can submit an attestation and increment their counter.
+    ///
+    /// Uses the per-attestor config override when one exists, otherwise falls back to the
+    /// global config.
     ///
     /// Returns `Ok(())` if the attestor is within the rate limit.
     /// Returns `Err(AnchorKitError::rate_limit_exceeded())` if the limit is exceeded.
     pub fn check_and_increment(
         env: &Env,
         attestor: &Address,
-        config: &RateLimitConfig,
     ) -> Result<(), AnchorKitError> {
+        let config = Self::get_effective_config(env, attestor);
         let current_ledger = env.ledger().sequence();
         let state_key = Self::get_state_key(env, attestor);
         
@@ -79,19 +82,27 @@ impl RateLimiter {
             })
     }
     
-    /// Update the rate limit configuration (admin only)
+    /// Update the global rate limit configuration, or set a per-attestor override when
+    /// `attestor` is `Some`.
     pub fn update_config(
         env: &Env,
         _admin: &Address,
         config: &RateLimitConfig,
+        attestor: Option<&Address>,
     ) -> Result<(), AnchorKitError> {
-        // In a real contract, you would check that admin is authorized
-        // For now, we'll just store the config
-        let config_key = Self::get_config_key(env);
-        env.storage().persistent().set(&config_key, config);
+        match attestor {
+            Some(addr) => {
+                let key = Self::get_attestor_config_key(env, addr);
+                env.storage().persistent().set(&key, config);
+            }
+            None => {
+                let key = Self::get_config_key(env);
+                env.storage().persistent().set(&key, config);
+            }
+        }
         Ok(())
     }
-    
+
     /// Get the current rate limit configuration
     pub fn get_config(env: &Env) -> RateLimitConfig {
         let config_key = Self::get_config_key(env);
@@ -100,6 +111,13 @@ impl RateLimiter {
                 max_submissions: 10,
                 window_length: 100,
             })
+    }
+
+    /// Get the effective config for an attestor: per-attestor override if set, else global.
+    pub fn get_effective_config(env: &Env, attestor: &Address) -> RateLimitConfig {
+        let key = Self::get_attestor_config_key(env, attestor);
+        env.storage().persistent().get::<_, RateLimitConfig>(&key)
+            .unwrap_or_else(|| Self::get_config(env))
     }
     
     /// Check if a window has expired
@@ -129,6 +147,19 @@ impl RateLimiter {
         let config_key = *b"rate_limit_config_______________";
         soroban_sdk::BytesN::from_array(env, &config_key)
     }
+
+    /// Generate storage key for a per-attestor config override
+    fn get_attestor_config_key(env: &Env, attestor: &Address) -> soroban_sdk::BytesN<32> {
+        let address_str = attestor.to_string();
+        let mut buf = [0u8; 56];
+        address_str.copy_into_slice(&mut buf);
+        // Prefix with a distinct byte so it never collides with the state key
+        let mut prefixed = [0u8; 57];
+        prefixed[0] = b'c'; // 'c' for config
+        prefixed[1..].copy_from_slice(&buf);
+        let bytes = soroban_sdk::Bytes::from_slice(env, &prefixed);
+        env.crypto().sha256(&bytes).into()
+    }
 }
 
 #[cfg(test)]
@@ -136,156 +167,209 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
 
+    fn make_contract(env: &Env) -> Address {
+        <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(env)
+    }
+
     #[test]
     fn test_rate_limit_under_limit() {
         let env = Env::default();
         let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        let config = RateLimitConfig {
-            max_submissions: 10,
-            window_length: 100,
-        };
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // Register a dummy contract for testing
+        let contract_address = make_contract(&env);
         let contract_id = env.register_contract(&contract_address, crate::rate_limiter::RateLimiter);
-        
-        // Should succeed for first submission
+
+        // Set global config with limit of 10
+        env.as_contract(&contract_id, &|| {
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 10, window_length: 100 }, None).unwrap();
+        });
+
         let result = env.as_contract(&contract_id, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         });
         assert!(result.is_ok());
-        
-        // Check state
+
         let state = env.as_contract(&contract_id, &|| {
             RateLimiter::get_state(&env, &attestor)
         });
         assert_eq!(state.submission_count, 1);
     }
-    
+
     #[test]
     fn test_rate_limit_at_limit() {
         let env = Env::default();
         let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        let config = RateLimitConfig {
-            max_submissions: 2,
-            window_length: 100,
-        };
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // First two submissions should succeed
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 2, window_length: 100 }, None).unwrap();
+        });
+
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         }).is_ok());
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         }).is_ok());
-        
-        // Third submission should fail
+
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         });
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
     }
-    
+
     #[test]
     fn test_rate_limit_over_limit() {
         let env = Env::default();
         let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        let config = RateLimitConfig {
-            max_submissions: 1,
-            window_length: 100,
-        };
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // First submission should succeed
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 1, window_length: 100 }, None).unwrap();
+        });
+
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         }).is_ok());
-        
-        // Second submission should fail
+
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         });
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
     }
-    
+
     #[test]
     fn test_rate_limit_window_reset() {
         let env = Env::default();
         let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        let config = RateLimitConfig {
-            max_submissions: 1,
-            window_length: 10,
-        };
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // First submission should succeed
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 1, window_length: 10 }, None).unwrap();
+        });
+
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         }).is_ok());
-        
-        // Second submission should fail
         assert!(env.as_contract(&contract_address, &|| {
-            RateLimiter::check_and_increment(&env, &attestor, &config)
+            RateLimiter::check_and_increment(&env, &attestor)
         }).is_err());
-        
-        // Note: In Soroban SDK, we cannot directly set the ledger sequence in tests
-        // The window reset logic will be tested in integration tests with actual ledger progression
-        // For now, we verify the state is correct
+
         let state = env.as_contract(&contract_address, &|| {
             RateLimiter::get_state(&env, &attestor)
         });
         assert_eq!(state.submission_count, 2);
     }
-    
+
     #[test]
     fn test_rate_limit_config_update() {
         let env = Env::default();
         let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        let new_config = RateLimitConfig {
-            max_submissions: 20,
-            window_length: 200,
-        };
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // Update config
+        let contract_address = make_contract(&env);
+        let new_config = RateLimitConfig { max_submissions: 20, window_length: 200 };
+
         let result = env.as_contract(&contract_address, &|| {
-            RateLimiter::update_config(&env, &admin, &new_config)
+            RateLimiter::update_config(&env, &admin, &new_config, None)
         });
         assert!(result.is_ok());
-        
-        // Verify config was updated
+
         let config = env.as_contract(&contract_address, &|| {
             RateLimiter::get_config(&env)
         });
         assert_eq!(config.max_submissions, 20);
         assert_eq!(config.window_length, 200);
     }
-    
+
     #[test]
     fn test_rate_limit_default_config() {
         let env = Env::default();
-        
-        // Create a dummy contract address for testing
-        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
-        
-        // Get default config
+        let contract_address = make_contract(&env);
+
         let config = env.as_contract(&contract_address, &|| {
             RateLimiter::get_config(&env)
         });
         assert_eq!(config.max_submissions, 10);
         assert_eq!(config.window_length, 100);
+    }
+
+    // --- per-attestor override tests ---
+
+    #[test]
+    fn test_per_attestor_override_takes_precedence() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            // Global: limit 1
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 1, window_length: 100 }, None).unwrap();
+            // Per-attestor override: limit 5
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 5, window_length: 100 }, Some(&attestor)).unwrap();
+        });
+
+        // Should succeed 5 times (override), not just 1 (global)
+        for _ in 0..5 {
+            assert!(env.as_contract(&contract_address, &|| {
+                RateLimiter::check_and_increment(&env, &attestor)
+            }).is_ok());
+        }
+        // 6th should fail
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &attestor)
+        }).is_err());
+    }
+
+    #[test]
+    fn test_fallback_to_global_when_no_override() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            // Global: limit 2, no per-attestor override
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 2, window_length: 100 }, None).unwrap();
+        });
+
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &attestor)
+        }).is_ok());
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &attestor)
+        }).is_ok());
+        // 3rd exceeds global limit
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &attestor)
+        }).is_err());
+    }
+
+    #[test]
+    fn test_override_does_not_affect_other_attestors() {
+        let env = Env::default();
+        let high_volume = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let normal = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_address = make_contract(&env);
+
+        env.as_contract(&contract_address, &|| {
+            // Global: limit 1
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 1, window_length: 100 }, None).unwrap();
+            // Override only for high_volume
+            RateLimiter::update_config(&env, &contract_address, &RateLimitConfig { max_submissions: 10, window_length: 100 }, Some(&high_volume)).unwrap();
+        });
+
+        // high_volume can submit 10 times
+        for _ in 0..10 {
+            assert!(env.as_contract(&contract_address, &|| {
+                RateLimiter::check_and_increment(&env, &high_volume)
+            }).is_ok());
+        }
+
+        // normal attestor is still capped at 1
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &normal)
+        }).is_ok());
+        assert!(env.as_contract(&contract_address, &|| {
+            RateLimiter::check_and_increment(&env, &normal)
+        }).is_err());
     }
 }


### PR DESCRIPTION
 Title: feat: per-attestor rate limit overrides                                                                      
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  Problem                                                                                                             
                                                                                                                      
  The existing RateLimiter applied a single global config to every attestor. This made it impossible to:              
                                                                                                                      
  - Give high-volume anchors a higher submission allowance                                                            
  - Enforce stricter limits on untrusted or low-trust attestors                                                       
                                                                                                                      
  Solution                                                                                                            
                                                                                                                      
  Extend RateLimiter to support per-attestor config overrides stored alongside the global config. check_and_increment 
   resolves the effective config at call time — per-attestor override takes precedence, global config is the          
  fallback.                                                                                                           
  Changes                                                                                                             
                                                                                                                      
  `src/rate_limiter.rs`                                                                                               
                                                                                                                      
  `update_config` — new attestor: Option<&Address> parameter                                                          
                                                                                                                      
  - None → updates the global config (existing behavior, backward compatible)                                         
  - Some(addr) → stores an override scoped to that attestor under a distinct hashed storage key                       
                                                                                                                      
  `check_and_increment` — removed config: &RateLimitConfig parameter                                                  
                                                                                                                      
  - Resolves config internally via get_effective_config                                                               
  - Callers no longer need to fetch and pass config manually                                                          
                                                                                                                      
  New methods                                                                                                         
                                                                                                                      
  - get_effective_config(env, attestor) — public; returns per-attestor override if present, else global config        
  - get_attestor_config_key(env, attestor) — private; hashes 'c' + address_bytes to produce a storage key that cannot 
  collide with the state key                                                                                          
                                                                                                                      
  Tests                                                                                                               
                                                                                                                      
  ┌───────────────────────────────────────────────┬─────────────────────────────────────────────────────────┐         
  │ Test                                            │ What it verifies                                           │    
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤    
  │ `test_per_attestor_override_takes_precedence`   │ Override limit (5) is used instead of global limit (1)     │    
  │ `test_fallback_to_global_when_no_override`      │ Attestor with no override is capped at the global limit    │    
  │ `test_override_does_not_affect_other_attestors` │ Override on one attestor does not change limits for others │    
  └─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘    
                                                                                                                      
  All 6 pre-existing tests updated to match the new update_config and check_and_increment signatures.                 
                                                                                                                      
  Backward Compatibility                                                                                              
                                                                                                                      
  - get_config is unchanged                                                                                           
  - Passing None to update_config is identical to the old call — no migration needed                                  
  - Any caller previously passing a config to check_and_increment needs to drop that argument; the method now         
  self-resolves it                                                                                                    
                                                                                                                      
  Acceptance Criteria                                                                                                 
                                                                                                                      
  - [x] Per-attestor config storage added (get_attestor_config_key, update_config with Some(addr))                    
  - [x] check_and_increment checks attestor-specific config first, falls back to global                               
  - [x] Tests for override and fallback behavior          
  
  closes #245 