### PR TITLE
fix: resolve issues #250, #251, #252, #253

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1171,6 +1171,15 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         }
     }
 
+    /// Return all anchor addresses that have been registered via `set_anchor_metadata`.
+    /// Returns an empty `Vec` when no anchors have been registered.
+    pub fn get_routing_anchors(env: Env) -> Vec<Address> {
+        let list_key = soroban_sdk::vec![&env, symbol_short!("ANCHLIST")];
+        env.storage().persistent()
+            .get::<_, Vec<Address>>(&list_key)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
     pub fn route_transaction(env: Env, options: RoutingOptions) -> Quote {
         let now = env.ledger().timestamp();
         let list_key = soroban_sdk::vec![&env, symbol_short!("ANCHLIST")];

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -24,6 +24,8 @@ pub struct RateLimitState {
     pub submission_count: u32,
     /// Ledger number when the current window started
     pub window_start_ledger: u32,
+    /// Cumulative total requests across all windows (never reset)
+    pub total_requests: u64,
 }
 
 /// Rate limiter for attestation submissions
@@ -47,22 +49,25 @@ impl RateLimiter {
             .unwrap_or(RateLimitState {
                 submission_count: 0,
                 window_start_ledger: current_ledger,
+                total_requests: 0,
             });
         
         // Check if window has expired and reset if needed
         if Self::is_window_expired(current_ledger, state.window_start_ledger, config.window_length) {
-            state = RateLimitState {
-                submission_count: 0,
-                window_start_ledger: current_ledger,
-            };
+            state.submission_count = 0;
+            state.window_start_ledger = current_ledger;
         }
         
+        // Increment total_requests on every call regardless of window state
+        state.total_requests += 1;
+
         // Check if limit is exceeded
         if state.submission_count >= config.max_submissions {
+            env.storage().persistent().set(&state_key, &state);
             return Err(AnchorKitError::rate_limit_exceeded());
         }
         
-        // Increment counter and save state
+        // Increment window counter and save state
         state.submission_count += 1;
         env.storage().persistent().set(&state_key, &state);
         
@@ -76,6 +81,7 @@ impl RateLimiter {
             .unwrap_or(RateLimitState {
                 submission_count: 0,
                 window_start_ledger: env.ledger().sequence(),
+                total_requests: 0,
             })
     }
     
@@ -287,5 +293,49 @@ mod tests {
         });
         assert_eq!(config.max_submissions, 10);
         assert_eq!(config.window_length, 100);
+    }
+
+    #[test]
+    fn test_total_requests_accumulates_across_windows() {
+        use soroban_sdk::testutils::{Ledger, LedgerInfo};
+
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig {
+            max_submissions: 2,
+            window_length: 10,
+        };
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let set_seq = |env: &Env, seq: u32| {
+            env.ledger().set(LedgerInfo {
+                timestamp: 0,
+                protocol_version: 21,
+                sequence_number: seq,
+                network_id: Default::default(),
+                base_reserve: 0,
+                min_persistent_entry_ttl: 4096,
+                min_temp_entry_ttl: 16,
+                max_entry_ttl: 6312000,
+            });
+        };
+
+        // Window 1: 2 successful + 1 rejected = 3 total_requests
+        set_seq(&env, 0);
+        assert!(env.as_contract(&contract_address, &|| RateLimiter::check_and_increment(&env, &attestor, &config)).is_ok());
+        assert!(env.as_contract(&contract_address, &|| RateLimiter::check_and_increment(&env, &attestor, &config)).is_ok());
+        assert!(env.as_contract(&contract_address, &|| RateLimiter::check_and_increment(&env, &attestor, &config)).is_err());
+
+        let state = env.as_contract(&contract_address, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, 2);
+        assert_eq!(state.total_requests, 3);
+
+        // Window 2 (advance ledger past window_length): 1 successful = 4 total_requests
+        set_seq(&env, 20);
+        assert!(env.as_contract(&contract_address, &|| RateLimiter::check_and_increment(&env, &attestor, &config)).is_ok());
+
+        let state = env.as_contract(&contract_address, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, 1, "window counter should reset");
+        assert_eq!(state.total_requests, 4, "total_requests should be cumulative");
     }
 }

--- a/src/routing_tests.rs
+++ b/src/routing_tests.rs
@@ -331,4 +331,40 @@ mod routing_tests {
         assert_eq!(best.anchor, anchor2);
         assert_eq!(best.fee_percentage, 25);
     }
+
+    #[test]
+    fn test_get_routing_anchors_empty_on_fresh_state() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchors = client.get_routing_anchors();
+        assert_eq!(anchors.len(), 0);
+    }
+
+    #[test]
+    fn test_get_routing_anchors_returns_all_registered() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor1 = Address::generate(&env);
+        let anchor2 = Address::generate(&env);
+        let anchor3 = Address::generate(&env);
+
+        register_anchor(&env, &client, &anchor1);
+        client.set_anchor_metadata(&anchor1, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+
+        register_anchor(&env, &client, &anchor2);
+        client.set_anchor_metadata(&anchor2, &7000u32, &400u64, &6500u32, &9800u32, &500_000u64);
+
+        register_anchor(&env, &client, &anchor3);
+        client.set_anchor_metadata(&anchor3, &6000u32, &500u64, &5500u32, &9700u32, &250_000u64);
+
+        let anchors = client.get_routing_anchors();
+        assert_eq!(anchors.len(), 3);
+        assert!(anchors.contains(&anchor1));
+        assert!(anchors.contains(&anchor2));
+        assert!(anchors.contains(&anchor3));
+    }
 }

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -82,7 +82,7 @@ fn parse_json_exp(payload: &[u8]) -> Result<u64, ()> {
     Ok(n)
 }
 
-/// Parse first `"sub":"..."` string value (no escape sequences inside value).
+/// Parse first `"sub":"..."` string value, handling `\"` escape sequences.
 fn parse_json_sub(env: &Env, payload: &[u8]) -> Result<String, ()> {
     let key = b"\"sub\":";
     let pos = find_bytes(payload, key).ok_or(())?;
@@ -96,6 +96,14 @@ fn parse_json_sub(env: &Env, payload: &[u8]) -> Result<String, ()> {
     i += 1;
     let start = i;
     while i < payload.len() {
+        if payload[i] == b'\\' {
+            // skip escaped character; if nothing follows, it's malformed
+            if i + 1 >= payload.len() {
+                return Err(());
+            }
+            i += 2;
+            continue;
+        }
         if payload[i] == b'"' {
             let sub = &payload[start..i];
             return Ok(String::from_bytes(env, sub));
@@ -279,5 +287,43 @@ mod tests {
         let token = String::from_str(&env, jwt.as_str());
 
         assert!(verify_sep10_jwt(&env, &token, &pk, Some(&sub)).is_err());
+
+        // Malformed payloads should also return Err, not panic
+        let malformed_cases: &[&[u8]] = &[
+            b"",                                    // empty payload
+            b"not json at all",                     // bad JSON
+            b"{\"sub\":\"val\\\"ue\",\"exp\":9999}", // escaped quote in sub value
+            b"{\"sub\":\"unterminated",             // truncated / no closing quote
+        ];
+        for payload in malformed_cases {
+            assert!(
+                parse_json_sub(&env, payload).is_err(),
+                "expected Err for payload: {:?}",
+                payload
+            );
+        }
+    }
+
+    #[test]
+    fn parse_json_sub_malformed_inputs_return_none() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+
+        let cases: &[&[u8]] = &[
+            b"",                                          // empty
+            b"{}",                                        // no sub key
+            b"{\"sub\":42}",                              // sub not a string
+            b"{\"sub\":\"val\\\"ue\",\"exp\":9999}",      // escaped quote in sub
+            b"{\"sub\":\"unterminated",                   // truncated base64 / no closing quote
+            b"{\"sub\":\"\\",                             // backslash at end (malformed escape)
+        ];
+
+        for payload in cases {
+            assert!(
+                parse_json_sub(&env, payload).is_err(),
+                "expected Err for: {:?}",
+                payload
+            );
+        }
     }
 }

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -124,7 +124,7 @@ pub enum TransactionKind {
 
 impl TransactionKind {
     pub fn from_str(s: &str) -> Self {
-        match s {
+        match s.to_lowercase().as_str() {
             "withdrawal" | "withdraw" => Self::Withdrawal,
             _ => Self::Deposit,
         }
@@ -360,5 +360,19 @@ mod tests {
         raw.kind = Some("withdraw".to_string());
         let resp = fetch_transaction_status(raw).unwrap();
         assert_eq!(resp.kind, TransactionKind::Withdrawal);
+
+        // Mixed-case withdrawal variants
+        for s in &["Withdrawal", "WITHDRAWAL", "Withdraw", "WITHDRAW"] {
+            let mut r = raw_tx_status();
+            r.kind = Some(s.to_string());
+            assert_eq!(fetch_transaction_status(r).unwrap().kind, TransactionKind::Withdrawal, "failed for {s}");
+        }
+
+        // Mixed-case deposit variants
+        for s in &["Deposit", "DEPOSIT", "deposit"] {
+            let mut r = raw_tx_status();
+            r.kind = Some(s.to_string());
+            assert_eq!(fetch_transaction_status(r).unwrap().kind, TransactionKind::Deposit, "failed for {s}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes four issues in a single change set.

---

### Closes #250 — `parse_json_sub` panic fix (`src/sep10_jwt.rs`)

- Skip backslash-escaped characters (`\"`) instead of treating the escaped quote as the string terminator
- Return `Err(())` when a backslash appears at the last byte (malformed escape)
- No panic paths remain; all malformed inputs return `Err`
- Extended `verify_rejects_invalid_signature` with a loop over malformed payloads (empty, bad JSON, escaped quote in sub, truncated)
- Added `parse_json_sub_malformed_inputs_return_none` test covering six malformed cases

---

### Closes #251 — `get_routing_anchors()` view function (`src/contract.rs`, `src/routing_tests.rs`)

- Added `pub fn get_routing_anchors(env: Env) -> Vec<Address>` on `AnchorKitContract`
- Reads the existing `ANCHLIST` persistent key already maintained by `set_anchor_metadata`
- Returns an empty `Vec` when no anchors are registered
- Added `test_get_routing_anchors_empty_on_fresh_state`
- Added `test_get_routing_anchors_returns_all_registered` (3 anchors)

---

### Closes #252 — `TransactionKind::from_str` case-insensitive (`src/sep6.rs`)

- Apply `.to_lowercase()` before matching
- `"Deposit"`, `"DEPOSIT"`, `"deposit"` all map to `Deposit`
- `"Withdrawal"`, `"WITHDRAWAL"`, `"Withdraw"`, `"WITHDRAW"` all map to `Withdrawal`
- Extended `test_withdrawal_kind_normalization` with mixed-case variants for both kinds

---

### Closes #253 — `RateLimitState` lifetime request counter (`src/rate_limiter.rs`)

- Added `total_requests: u64` field to `RateLimitState`
- Incremented on **every** `check_and_increment` call, including rejected ones, before the limit check
- Window expiry only resets `submission_count` and `window_start_ledger` — `total_requests` is never reset
- Added `test_total_requests_accumulates_across_windows`: 3 calls in window 1 (2 ok + 1 rejected), 1 call in window 2 → asserts `submission_count == 1` and `total_requests == 4`