### PR TITLE
fix: add next_attestation_id overflow guard (#224)

### DIFF
--- a/src/attestation_pagination_tests.rs
+++ b/src/attestation_pagination_tests.rs
@@ -181,6 +181,32 @@ mod attestation_pagination_tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_attestation_id_overflow_panics() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Seed the counter to u64::MAX so the next increment overflows
+        env.as_contract(&contract_id, &|| {
+            let ck = soroban_sdk::vec![&env, soroban_sdk::symbol_short!("COUNTER")];
+            env.storage().instance().set(&ck, &u64::MAX);
+        });
+
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // This should panic due to overflow guard
+        client.submit_attestation(&attestor, &subject, &1700000001, &payload(&env, 1), &sig(&env, 1));
+    }
+
+    #[test]
     fn test_list_attestations_offset_out_of_bounds() {
         let env = make_env();
         setup_ledger(&env);

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1575,7 +1575,8 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         let inst = env.storage().instance();
         let ck = soroban_sdk::vec![env, symbol_short!("COUNTER")];
         let id: u64 = inst.get(&ck).unwrap_or(0u64);
-        inst.set(&ck, &(id + 1));
+        let next = id.checked_add(1).unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        inst.set(&ck, &next);
         inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         id
     }


### PR DESCRIPTION


---

## Summary

Fixes the silent u64 wraparound bug in `next_attestation_id` reported in issue #224.

## Problem

`next_attestation_id` used `id + 1` with no overflow check. On a long-running deployment where the counter reaches `u64::MAX`, the addition would wrap around to `0`, silently reusing attestation IDs and corrupting the audit trail.

## Solution

Replace `id + 1` with `checked_add(1)`. If the counter would overflow, `panic_with_error!` is called with `ErrorCode::ValidationError`, halting execution with a clear error rather than allowing silent data corruption.

```rust
// Before
inst.set(&ck, &(id + 1));

// After
let next = id.checked_add(1).unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
inst.set(&ck, &next);
```

## Changes

- `src/contract.rs`: overflow guard in `next_attestation_id`
- `src/attestation_pagination_tests.rs`: near-overflow test that seeds the counter to `u64::MAX` via `env.as_contract` and asserts the guard panics

## Acceptance Criteria

- [x] Overflow guard added
- [x] Test simulates near-overflow scenario

Closes #224