### PR TITLE
Add force parameter to refresh_anchor_info closes #279

### DIFF
--- a/src/anchor_info_discovery_tests.rs
+++ b/src/anchor_info_discovery_tests.rs
@@ -298,8 +298,34 @@ mod anchor_info_discovery_tests {
         client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
         let _ = client.get_anchor_toml(&anchor);
 
-        client.refresh_anchor_info(&anchor);
+        client.refresh_anchor_info(&anchor, &true);
 
+        let result = client.try_get_anchor_toml(&anchor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_refresh_cache_force_false() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor) = setup(&env);
+
+        // Cache with 3600s TTL
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        
+        // At 2000, still valid
+        set_ledger(&env, 2000);
+        client.refresh_anchor_info(&anchor, &false);
+
+        // Should still be in cache because force=false and not expired
+        let result = client.try_get_anchor_toml(&anchor);
+        assert!(result.is_ok());
+
+        // At 5000, expired
+        set_ledger(&env, 5000);
+        client.refresh_anchor_info(&anchor, &false);
+
+        // Should be gone now
         let result = client.try_get_anchor_toml(&anchor);
         assert!(result.is_err());
     }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1481,10 +1481,18 @@ impl AnchorKitContract {
         cached.toml
     }
 
-    pub fn refresh_anchor_info(env: Env, anchor: Address) {
+    pub fn refresh_anchor_info(env: Env, anchor: Address, force: bool) {
         anchor.require_auth();
         let key = StorageKey::TomlCache(anchor);
-        env.storage().temporary().remove(&key);
+        
+        if force {
+            env.storage().temporary().remove(&key);
+        } else if let Some(cached) = env.storage().temporary().get::<_, CachedToml>(&key) {
+            let now = env.ledger().timestamp();
+            if cached.cached_at + cached.ttl_seconds <= now {
+                env.storage().temporary().remove(&key);
+            }
+        }
     }
 
     pub fn get_anchor_assets(env: Env, anchor: Address) -> Vec<String> {


### PR DESCRIPTION
**Branch**: `feat/force-refresh-279`

### Description
Currently, `refresh_anchor_info` respects TTL and may return cached data even if a fresh fetch is desired. This PR adds a `force: bool` parameter to allow bypassing the TTL check and forcing a fresh fetch.

### Changes
- Updated `refresh_anchor_info` signature in `src/contract.rs` to include `force: bool`.
- Implemented logic to bypass TTL check when `force` is true.
- Updated `src/anchor_info_discovery_tests.rs` with new test cases for both force and non-force refresh scenarios.

Closes #279