### PR TITLE
feat(routing): improve balanced strategy reputation term scaling

### DIFF
--- a/docs/features/ROUTING_STRATEGY.md
+++ b/docs/features/ROUTING_STRATEGY.md
@@ -23,20 +23,22 @@ the `strategy` vec:
 ```
 score = (40_000 / fee_percentage)
       + (30_000 / average_settlement_time)
-      + (reputation_score * 30 / 10_000)
+      + (reputation_score * 3_000 / 10_000)
 ```
 
 All three terms are dimensionless and comparable. A zero `fee_percentage` or
 `average_settlement_time` contributes `0` to that term (no division by zero).
+The reputation term scales the 0–10_000 score into a 0–3_000 range so it
+carries meaningful weight alongside the other two terms.
 The anchor with the highest total score is selected.
 
 Example with three anchors:
 
 | Anchor | fee | time (s) | reputation | fee term | time term | rep term | score |
 |--------|-----|----------|------------|----------|-----------|----------|-------|
-| A | 10 | 1000 | 2000 | 4000 | 30 | 6 | **4036** |
-| C | 20 | 200 | 6000 | 2000 | 150 | 18 | 2168 |
-| B | 50 | 100 | 9000 | 800 | 300 | 27 | 1127 |
+| A | 10 | 1000 | 2000 | 4000 | 30 | 600 | **4630** |
+| C | 20 | 200 | 6000 | 2000 | 150 | 1800 | 3950 |
+| B | 50 | 100 | 9000 | 800 | 300 | 2700 | 3800 |
 
 Anchor A wins despite slow speed and low reputation because its very low fee
 dominates the score.

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1053,7 +1053,7 @@ impl AnchorKitContract {
                 }
             }
         } else if strategy_sym == balanced_sym {
-            // score = (40_000 / fee_percentage) + (30_000 / settlement_time) + (reputation * 30 / 10_000)
+            // score = (40_000 / fee_percentage) + (30_000 / settlement_time) + (reputation * 3_000 / 10_000)
             // All terms are dimensionless integers; higher score is better.
             // fee_percentage = 0 or settlement_time = 0 contribute 0 to avoid division by zero.
             let balanced_score = |env: &Env, q: &Quote| -> u64 {
@@ -1071,7 +1071,8 @@ impl AnchorKitContract {
                     });
                 let fee_term = if q.fee_percentage > 0 { 40_000 / q.fee_percentage as u64 } else { 0 };
                 let time_term = if meta.average_settlement_time > 0 { 30_000 / meta.average_settlement_time } else { 0 };
-                let rep_term = meta.reputation_score as u64 * 30 / 10_000;
+                // Scale reputation (0–10_000) to a 0–3_000 range to match the weight of other terms.
+                let rep_term = meta.reputation_score as u64 * 3_000 / 10_000;
                 fee_term + time_term + rep_term
             };
             let mut best_score = balanced_score(&env, &best);

--- a/src/routing_tests.rs
+++ b/src/routing_tests.rs
@@ -460,10 +460,10 @@ mod routing_tests {
         let (client, _) = setup(&env);
 
         // Anchor A: low fee (10), slow (1000s), low reputation (2000)
-        //   fee_term  = 40_000 / 10  = 4000
+        //   fee_term  = 40_000 / 10   = 4000
         //   time_term = 30_000 / 1000 = 30
-        //   rep_term  = 2000 * 30 / 10_000 = 6
-        //   score = 4036
+        //   rep_term  = 2000 * 3_000 / 10_000 = 600
+        //   score = 4630
         let anchor_a = Address::generate(&env);
         register_anchor(&env, &client, &anchor_a);
         client.set_anchor_metadata(&anchor_a, &2000u32, &1000u64, &7500u32, &9900u32, &1_000_000u64);
@@ -477,8 +477,8 @@ mod routing_tests {
         // Anchor B: high fee (50), fast (100s), high reputation (9000)
         //   fee_term  = 40_000 / 50  = 800
         //   time_term = 30_000 / 100 = 300
-        //   rep_term  = 9000 * 30 / 10_000 = 27
-        //   score = 1127
+        //   rep_term  = 9000 * 3_000 / 10_000 = 2700
+        //   score = 3800
         let anchor_b = Address::generate(&env);
         register_anchor(&env, &client, &anchor_b);
         client.set_anchor_metadata(&anchor_b, &9000u32, &100u64, &7500u32, &9900u32, &1_000_000u64);
@@ -492,8 +492,8 @@ mod routing_tests {
         // Anchor C: medium fee (20), medium speed (200s), medium reputation (6000)
         //   fee_term  = 40_000 / 20  = 2000
         //   time_term = 30_000 / 200 = 150
-        //   rep_term  = 6000 * 30 / 10_000 = 18
-        //   score = 2168
+        //   rep_term  = 6000 * 3_000 / 10_000 = 1800
+        //   score = 3950
         let anchor_c = Address::generate(&env);
         register_anchor(&env, &client, &anchor_c);
         client.set_anchor_metadata(&anchor_c, &6000u32, &200u64, &7500u32, &9900u32, &1_000_000u64);
@@ -514,7 +514,7 @@ mod routing_tests {
             require_kyc: false,
         };
 
-        // anchor_a wins: score 4036 > anchor_c 2168 > anchor_b 1127
+        // anchor_a wins: score 4630 > anchor_c 3950 > anchor_b 3800
         let best = client.route_transaction(&options);
         assert_eq!(best.anchor, anchor_a);
     }


### PR DESCRIPTION
Scale rep_term from * 30 / 10_000 (max 30) to * 3_000 / 10_000 (max 3_000) so reputation carries meaningful 30% weight alongside fee and speed terms.

Closes #243 

