### PR TITLE
SEP-6: add Unknown status variant, fee_percent, address validation, list_transactions

### DIFF
--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -5,11 +5,10 @@
 
 
 extern crate alloc;
-use alloc::string::String;
-#[cfg(test)]
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
-use crate::errors::Error;
+use crate::errors::{Error, ErrorCode};
 
 // ── Normalized response types ────────────────────────────────────────────────
 
@@ -26,6 +25,7 @@ pub enum TransactionStatus {
     Refunded,
     Expired,
     Error,
+    Unknown(String),
 }
 
 impl TransactionStatus {
@@ -41,11 +41,11 @@ impl TransactionStatus {
             "expired" => Self::Expired,
             "incomplete" => Self::Incomplete,
             "pending" => Self::Pending,
-            _ => Self::Error,
+            _ => Self::Unknown(s.to_string()),
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Pending => "pending",
             Self::Incomplete => "incomplete",
@@ -57,6 +57,7 @@ impl TransactionStatus {
             Self::Refunded => "refunded",
             Self::Expired => "expired",
             Self::Error => "error",
+            Self::Unknown(s) => s.as_str(),
         }
     }
 }
@@ -76,6 +77,8 @@ pub struct DepositResponse {
     pub max_amount: Option<u64>,
     /// Fee charged for the deposit, if provided.
     pub fee_fixed: Option<u64>,
+    /// Percentage fee charged for the deposit in basis points, if provided (e.g. `150` = 1.50%).
+    pub fee_percent: Option<u32>,
     /// Current status of the transaction.
     pub status: TransactionStatus,
 }
@@ -99,6 +102,8 @@ pub struct WithdrawalResponse {
     pub max_amount: Option<u64>,
     /// Fee charged for the withdrawal, if provided.
     pub fee_fixed: Option<u64>,
+    /// Percentage fee charged for the withdrawal in basis points, if provided (e.g. `150` = 1.50%).
+    pub fee_percent: Option<u32>,
     /// Current status of the transaction.
     pub status: TransactionStatus,
 }
@@ -147,8 +152,11 @@ pub struct RawDepositResponse {
     pub min_amount: Option<u64>,
     pub max_amount: Option<u64>,
     pub fee_fixed: Option<u64>,
+    pub fee_percent: Option<u32>,
     /// Raw status string from the anchor (e.g. `"pending_external"`).
     pub status: Option<String>,
+    /// Optional Stellar account (G-address) of the depositor.
+    pub depositor_account: Option<String>,
 }
 
 /// Raw fields from an anchor's `/withdraw` response.
@@ -161,6 +169,7 @@ pub struct RawWithdrawalResponse {
     pub min_amount: Option<u64>,
     pub max_amount: Option<u64>,
     pub fee_fixed: Option<u64>,
+    pub fee_percent: Option<u32>,
     pub status: Option<String>,
 }
 
@@ -175,7 +184,25 @@ pub struct RawTransactionResponse {
     pub message: Option<String>,
 }
 
+/// Input parameters for fetching a list of transactions from an anchor.
+pub struct RawTransactionListRequest {
+    /// Stellar account (G-address) whose transactions to fetch.
+    pub account: String,
+    /// Asset code to filter by (e.g. `"USDC"`).
+    pub asset_code: String,
+    /// Maximum number of transactions to return.
+    pub limit: u32,
+    /// Pagination cursor — the transaction ID to start after, if any.
+    pub cursor: Option<String>,
+}
+
 // ── Service functions ─────────────────────────────────────────────────────────
+
+fn is_valid_stellar_address(s: &str) -> bool {
+    s.len() == 56
+        && s.starts_with('G')
+        && s.chars().all(|c| c.is_ascii_alphanumeric())
+}
 
 /// Normalize a raw anchor deposit response into a canonical [`DepositResponse`].
 ///
@@ -183,6 +210,15 @@ pub struct RawTransactionResponse {
 pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Error> {
     if raw.transaction_id.is_empty() || raw.how.is_empty() {
         return Err(Error::invalid_transaction_intent());
+    }
+    if let Some(ref acct) = raw.depositor_account {
+        if !is_valid_stellar_address(acct) {
+            return Err(Error::with_context(
+                ErrorCode::ValidationError,
+                "Invalid Stellar address",
+                acct,
+            ));
+        }
     }
 
     Ok(DepositResponse {
@@ -192,6 +228,7 @@ pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Erro
         min_amount: raw.min_amount,
         max_amount: raw.max_amount,
         fee_fixed: raw.fee_fixed,
+        fee_percent: raw.fee_percent,
         status: raw
             .status
             .as_deref()
@@ -217,6 +254,7 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse) -> Result<WithdrawalRespo
         min_amount: raw.min_amount,
         max_amount: raw.max_amount,
         fee_fixed: raw.fee_fixed,
+        fee_percent: raw.fee_percent,
         status: raw
             .status
             .as_deref()
@@ -251,6 +289,56 @@ pub fn fetch_transaction_status(
     })
 }
 
+/// Normalize a list of raw transaction responses for the given account and asset.
+///
+/// Returns `Err(Error::ValidationError)` if `account` is not a valid Stellar address
+/// or if `asset_code` is empty. Individual items that fail normalization are skipped.
+/// The `cursor` field in `req` is available for callers to pass to the anchor's API;
+/// this function applies it as a filter — items up to and including the cursor ID are
+/// dropped, mirroring standard cursor-based pagination.
+pub fn list_transactions(
+    req: RawTransactionListRequest,
+    raw_items: Vec<RawTransactionResponse>,
+) -> Result<Vec<TransactionStatusResponse>, Error> {
+    if !is_valid_stellar_address(&req.account) {
+        return Err(Error::with_context(
+            ErrorCode::ValidationError,
+            "Invalid Stellar address",
+            &req.account,
+        ));
+    }
+    if req.asset_code.is_empty() {
+        return Err(Error::with_context(
+            ErrorCode::ValidationError,
+            "asset_code must not be empty",
+            "asset_code",
+        ));
+    }
+
+    let mut skip = req.cursor.is_some();
+    let mut results = Vec::new();
+
+    for item in raw_items {
+        if let Some(ref cursor) = req.cursor {
+            if item.transaction_id == *cursor {
+                skip = false;
+                continue;
+            }
+            if skip {
+                continue;
+            }
+        }
+        if results.len() as u32 >= req.limit {
+            break;
+        }
+        if let Ok(normalized) = fetch_transaction_status(item) {
+            results.push(normalized);
+        }
+    }
+
+    Ok(results)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -265,7 +353,9 @@ mod tests {
             min_amount: Some(10),
             max_amount: Some(10_000),
             fee_fixed: Some(1),
+            fee_percent: None,
             status: Some("pending_external".to_string()),
+            depositor_account: None,
         }
     }
 
@@ -279,6 +369,7 @@ mod tests {
             min_amount: Some(5),
             max_amount: Some(5_000),
             fee_fixed: Some(2),
+            fee_percent: None,
             status: Some("pending_user".to_string()),
         }
     }
@@ -308,6 +399,22 @@ mod tests {
         let mut raw = raw_deposit();
         raw.transaction_id = "".to_string();
         assert_eq!(initiate_deposit(raw), Err(Error::invalid_transaction_intent()));
+    }
+
+    #[test]
+    fn test_initiate_deposit_invalid_stellar_address_returns_error() {
+        let mut raw = raw_deposit();
+        raw.depositor_account = Some("not-a-stellar-address".to_string());
+        let err = initiate_deposit(raw).unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn test_initiate_deposit_valid_stellar_address_accepted() {
+        let mut raw = raw_deposit();
+        // 56-char G-address
+        raw.depositor_account = Some("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN".to_string());
+        assert!(initiate_deposit(raw).is_ok());
     }
 
     #[test]
@@ -360,7 +467,7 @@ mod tests {
         let mut raw = raw_tx_status();
         raw.status = "some_unknown_status".to_string();
         let resp = fetch_transaction_status(raw).unwrap();
-        assert_eq!(resp.status, TransactionStatus::Error);
+        assert_eq!(resp.status, TransactionStatus::Unknown("some_unknown_status".to_string()));
     }
 
     #[test]
@@ -383,5 +490,108 @@ mod tests {
             r.kind = Some(s.to_string());
             assert_eq!(fetch_transaction_status(r).unwrap().kind, TransactionKind::Deposit, "failed for {s}");
         }
+    }
+
+    #[test]
+    fn test_initiate_deposit_fee_percent_propagated() {
+        let mut raw = raw_deposit();
+        raw.fee_percent = Some(150);
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.fee_percent, Some(150));
+    }
+
+    #[test]
+    fn test_initiate_withdrawal_fee_percent_propagated() {
+        let mut raw = raw_withdrawal();
+        raw.fee_percent = Some(50);
+        let resp = initiate_withdrawal(raw).unwrap();
+        assert_eq!(resp.fee_percent, Some(50));
+    }
+
+    // ── list_transactions ────────────────────────────────────────────────────
+
+    const VALID_ACCOUNT: &str = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+    fn make_raw_tx(id: &str, status: &str) -> RawTransactionResponse {
+        RawTransactionResponse {
+            transaction_id: id.to_string(),
+            kind: Some("deposit".to_string()),
+            status: status.to_string(),
+            amount_in: None,
+            amount_out: None,
+            amount_fee: None,
+            message: None,
+        }
+    }
+
+    fn base_req() -> RawTransactionListRequest {
+        RawTransactionListRequest {
+            account: VALID_ACCOUNT.to_string(),
+            asset_code: "USDC".to_string(),
+            limit: 10,
+            cursor: None,
+        }
+    }
+
+    #[test]
+    fn test_list_transactions_returns_all_items() {
+        let items = alloc::vec![
+            make_raw_tx("t1", "completed"),
+            make_raw_tx("t2", "pending"),
+        ];
+        let result = list_transactions(base_req(), items).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].transaction_id, "t1");
+        assert_eq!(result[1].transaction_id, "t2");
+    }
+
+    #[test]
+    fn test_list_transactions_respects_limit() {
+        let items = alloc::vec![
+            make_raw_tx("t1", "completed"),
+            make_raw_tx("t2", "completed"),
+            make_raw_tx("t3", "completed"),
+        ];
+        let mut req = base_req();
+        req.limit = 2;
+        let result = list_transactions(req, items).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_list_transactions_cursor_pagination() {
+        let items = alloc::vec![
+            make_raw_tx("t1", "completed"),
+            make_raw_tx("t2", "completed"),
+            make_raw_tx("t3", "completed"),
+        ];
+        let mut req = base_req();
+        req.cursor = Some("t1".to_string());
+        let result = list_transactions(req, items).unwrap();
+        // t1 is the cursor — items after it are t2, t3
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].transaction_id, "t2");
+    }
+
+    #[test]
+    fn test_list_transactions_invalid_account_returns_error() {
+        let result = list_transactions(
+            RawTransactionListRequest {
+                account: "bad-account".to_string(),
+                asset_code: "USDC".to_string(),
+                limit: 10,
+                cursor: None,
+            },
+            alloc::vec![],
+        );
+        assert_eq!(result.unwrap_err().code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn test_list_transactions_empty_asset_code_returns_error() {
+        let mut req = base_req();
+        req.asset_code = "".to_string();
+        let result = list_transactions(req, alloc::vec![]);
+        assert_eq!(result.unwrap_err().code, ErrorCode::ValidationError);
     }
 }


### PR DESCRIPTION
 (#232-#235)

- Add TransactionStatus::Unknown(String) variant; unrecognized status strings no longer map to Error (#232)
- Add fee_percent: Option<u32> (basis points) to DepositResponse, WithdrawalResponse, and their raw input types; propagated through initiate_deposit and initiate_withdrawal (#233)
- Validate depositor_account in initiate_deposit against Stellar G-address format (56 chars, starts with G, ASCII alphanumeric) (#234)
- Implement list_transactions with account/asset validation and cursor-based pagination (#235)
Closes #232 
Closes #233 
Closes #234 
Closes #235 