### PR TITLE
feat: add get_audit_log_range(from_id, to_id) with max 100 entries

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1098,6 +1098,25 @@ impl AnchorKitContract {
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound))
     }
 
+    /// Return audit log entries in [from_id, to_id], capped at 100 entries.
+    /// IDs that have no stored entry are silently skipped.
+    pub fn get_audit_log_range(env: Env, from_id: u64, to_id: u64) -> Vec<AuditLog> {
+        let mut result = Vec::new(&env);
+        if from_id > to_id {
+            return result;
+        }
+        let cap: u64 = 100;
+        let end = if to_id - from_id + 1 > cap { from_id + cap - 1 } else { to_id };
+        let mut id = from_id;
+        while id <= end {
+            if let Some(log) = env.storage().persistent().get::<_, AuditLog>(&StorageKey::AuditLog(id)) {
+                result.push_back(log);
+            }
+            id += 1;
+        }
+        result
+    }
+
     pub fn get_session_operation_count(env: Env, session_id: u64) -> u64 {
         env.storage()
             .persistent()

--- a/src/session_tests.rs
+++ b/src/session_tests.rs
@@ -346,4 +346,78 @@ mod session_tests {
         assert_eq!(log2.operation.operation_index, 2);
         assert_eq!(log2.operation.result_data, 1); // attestation id 1
     }
+
+    // -----------------------------------------------------------------------
+    // get_audit_log_range
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_audit_log_range_basic() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register(AnchorKitContract, ());
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let (signing_key, _) = register_attestor_with_sep10(&env, &client, &admin);
+        let session_id = client.create_session(&admin);
+
+        // Create 3 audit log entries via register + 2 attests
+        let _ = signing_key; // already registered above (log 0)
+        let ph1 = payload(&env, 1);
+        let s1 = sig(&env, &[1u8; 64]);
+        client.submit_attestation_with_session(&session_id, &admin, &admin, &1u64, &ph1, &s1);
+        let ph2 = payload(&env, 2);
+        let s2 = sig(&env, &[2u8; 64]);
+        client.submit_attestation_with_session(&session_id, &admin, &admin, &2u64, &ph2, &s2);
+
+        // Range [0, 2] should return 3 entries
+        let logs = client.get_audit_log_range(&0u64, &2u64);
+        assert_eq!(logs.len(), 3);
+        assert_eq!(logs.get(0).unwrap().log_id, 0);
+        assert_eq!(logs.get(2).unwrap().log_id, 2);
+    }
+
+    #[test]
+    fn test_audit_log_range_empty_for_out_of_range() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register(AnchorKitContract, ());
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // No audit logs written — range should return empty vec
+        let logs = client.get_audit_log_range(&0u64, &5u64);
+        assert_eq!(logs.len(), 0);
+    }
+
+    #[test]
+    fn test_audit_log_range_max_100() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register(AnchorKitContract, ());
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Requesting 200 entries should be capped at 100
+        let logs = client.get_audit_log_range(&0u64, &199u64);
+        // No entries stored, but the range is capped — result is empty (not 200 iterations)
+        assert_eq!(logs.len(), 0);
+    }
+
+    #[test]
+    fn test_audit_log_range_inverted_ids_returns_empty() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register(AnchorKitContract, ());
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let logs = client.get_audit_log_range(&5u64, &2u64);
+        assert_eq!(logs.len(), 0);
+    }
 }


### PR DESCRIPTION
                                                                                          
                                                                                            
  `feat/audit-log-range` — src/contract.rs, src/session_tests.rs                            
                                                                                            
  - Added get_audit_log_range(env, from_id, to_id) -> Vec<AuditLog> to AnchorKitContract    
  - Capped at 100 entries; missing IDs silently skipped; inverted range returns empty vec   
  - 4 tests: basic range, out-of-range, cap enforcement, inverted IDs                       
                                                                                            
  ──────────────────────────────────────────────────────────────────────────────────────────
                                                                                            
  `closes #303