### PR TITLE
feat: add get_transaction_count_by_state(state) O(1) counter

### DIFF
--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -50,6 +50,9 @@ pub struct TransactionStateRecord {
 pub struct TransactionStateTracker {
     cache: alloc::vec::Vec<TransactionStateRecord>,
     is_dev_mode: bool,
+    /// Per-state counters indexed by TransactionState discriminant (1-based).
+    /// Index 0 is unused; indices 1-4 map to Pending/InProgress/Completed/Failed.
+    state_counts: [u64; 5],
 }
 
 #[allow(dead_code)]
@@ -59,6 +62,7 @@ impl TransactionStateTracker {
         TransactionStateTracker {
             cache: alloc::vec::Vec::new(),
             is_dev_mode,
+            state_counts: [0u64; 5],
         }
     }
 
@@ -82,6 +86,7 @@ impl TransactionStateTracker {
 
         if self.is_dev_mode {
             self.cache.push(record.clone());
+            self.state_counts[TransactionState::Pending as usize] += 1;
         }
 
         Ok(record)
@@ -134,9 +139,15 @@ impl TransactionStateTracker {
             // Search and update in cache
             for record in self.cache.iter_mut() {
                 if record.transaction_id == transaction_id {
+                    let old_state = record.state;
                     record.state = new_state;
                     record.last_updated = current_time;
                     record.error_message = error_message;
+                    // Update per-state counters
+                    if self.state_counts[old_state as usize] > 0 {
+                        self.state_counts[old_state as usize] -= 1;
+                    }
+                    self.state_counts[new_state as usize] += 1;
                     return Ok(record.clone());
                 }
             }
@@ -210,6 +221,7 @@ impl TransactionStateTracker {
     pub fn clear_cache(&mut self) -> Result<(), String> {
         if self.is_dev_mode {
             self.cache = alloc::vec::Vec::new();
+            self.state_counts = [0u64; 5];
             Ok(())
         } else {
             Err(String::from_str(&Env::default(), "Cannot clear cache in production mode"))
@@ -219,6 +231,12 @@ impl TransactionStateTracker {
     /// Get cache size
     pub fn cache_size(&self) -> usize {
         self.cache.len()
+    }
+
+    /// Get the count of transactions in a given state — O(1).
+    /// More efficient than `get_transactions_by_state(...).len()`.
+    pub fn get_transaction_count_by_state(&self, state: TransactionState) -> u64 {
+        self.state_counts[state as usize]
     }
 }
 

--- a/src/transaction_state_tracker_tests.rs
+++ b/src/transaction_state_tracker_tests.rs
@@ -199,4 +199,54 @@ mod transaction_state_tracker_tests {
         assert_eq!(record2.timestamp, initial_timestamp);
         assert!(record2.last_updated >= initial_timestamp);
     }
+
+    #[test]
+    fn test_get_transaction_count_by_state_basic() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).ok();
+        tracker.create_transaction(2, initiator.clone(), &env).ok();
+        tracker.create_transaction(3, initiator.clone(), &env).ok();
+
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Pending), 3);
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::InProgress), 0);
+
+        tracker.start_transaction(1, &env).ok();
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Pending), 2);
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::InProgress), 1);
+
+        tracker.complete_transaction(1, &env).ok();
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::InProgress), 0);
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Completed), 1);
+    }
+
+    #[test]
+    fn test_get_transaction_count_by_state_failed() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).ok();
+        tracker.create_transaction(2, initiator.clone(), &env).ok();
+        let err = String::from_str(&env, "err");
+        tracker.fail_transaction(1, err, &env).ok();
+
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Pending), 1);
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Failed), 1);
+    }
+
+    #[test]
+    fn test_get_transaction_count_by_state_after_clear() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).ok();
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Pending), 1);
+
+        tracker.clear_cache().ok();
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Pending), 0);
+    }
 }


### PR DESCRIPTION
                 
                                                                                            
  `feat/transaction-count-by-state` — src/transaction_state_tracker.rs,                     
  src/transaction_state_tracker_tests.rs                                                    
                                                                                            
  - Added state_counts: [u64; 5] array (index = state discriminant, 1-based)                
  - Incremented on create_transaction (Pending), updated atomically in update_state         
   (decrement old, increment new), reset in clear_cache                                     
  - get_transaction_count_by_state(state) -> u64 is O(1)                                    
  - 3 tests: basic counting across transitions, failed state, post-clear reset              
            closes #301                                     