### PR TITLE
fix(#290): format percent fees with 2 decimal places and asset code

### DIFF
--- a/ui/components/AnchorCapabilityCard.tsx
+++ b/ui/components/AnchorCapabilityCard.tsx
@@ -114,7 +114,8 @@ const fmt = (n: number, currency: string) =>
 function fmtFee(fee?: AssetFee): string {
   if (!fee) return "—";
   if (fee.type === "flat") return fmt(fee.flatAmount!, fee.currency);
-  if (fee.type === "percent") return `${fee.percent}%`;
+  if (fee.type === "percent")
+    return `${Number(fee.percent).toFixed(2)}% ${fee.currency}`;
   if (fee.type === "tiered" && fee.tiers) return "Tiered";
   return "—";
 }
@@ -434,7 +435,7 @@ function FeesPanel({
             {df.type === "percent" && (
               <DataRow
                 label="Rate"
-                value={`${df.percent}%`}
+                value={`${Number(df.percent).toFixed(2)}% ${df.currency}`}
                 mono
                 accent={accent}
               />
@@ -504,7 +505,7 @@ function FeesPanel({
             {wf.type === "percent" && (
               <DataRow
                 label="Rate"
-                value={`${wf.percent}%`}
+                value={`${Number(wf.percent).toFixed(2)}% ${wf.currency}`}
                 mono
                 accent={accent}
               />


### PR DESCRIPTION
fix(#290): format percent fees with 2 decimal places and asset code

Fixes #290

The fees panel in AnchorCapabilityCard was displaying percent-type fees as raw numbers without decimal formatting or the asset currency code (e.g. 0.5% instead of 0.50% EUR).

What changed

fmtFee and both the deposit and withdrawal percent rows in FeesPanel now use toFixed(2) and append the fee's currency code. Flat fees were already handled correctly by the existing fmt() helper.

Before / After

Before	After
Percent fee	0.5%	0.50% EUR
Flat fee	EUR 0.50	EUR 0.50 (unchanged)
Testing

Verified against the demo data in AnchorCapabilityDemo — Vibrant's EURC deposit fee (0.1%) now renders as 0.10% EUR.

Closes #290 