### PR TITLE
feat: implement fmt::Display for AnchorKitError (#223)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -215,6 +215,15 @@ impl AnchorKitError {
     }
 }
 
+impl core::fmt::Display for AnchorKitError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match &self.context {
+            Some(context) => write!(f, "[E{}] {} ({})", self.code as u32, self.message, context),
+            None => write!(f, "[E{}] {}", self.code as u32, self.message),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Backward-compat type alias so existing code using `Error` still compiles
 // ---------------------------------------------------------------------------
@@ -330,4 +339,19 @@ mod tests {
         let b = a.clone();
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn test_display_format_without_context() {
+        let err = AnchorKitError::new(ErrorCode::RateLimitExceeded, "Rate limit exceeded");
+        let formatted = alloc::format!("{}", err);
+        assert_eq!(formatted, "[E16] Rate limit exceeded");
+    }
+
+    #[test]
+    fn test_display_format_with_context() {
+        let err = AnchorKitError::with_context(ErrorCode::ValidationError, "Schema mismatch", "field: transaction_id");
+        let formatted = alloc::format!("{}", err);
+        assert_eq!(formatted, "[E15] Schema mismatch (field: transaction_id)");
+    }
 }
+


### PR DESCRIPTION
## Description
Description
This PR resolves an issue where AnchorKitError only derived Debug, resulting in empty log lines when attempting to format errors using {}. We have now implemented core::fmt::Display to ensure structured, readable output across the application logs.

Closes #223.

Changes Made
Implemented core::fmt::Display for AnchorKitError using no_std compatible alloc primitives.
Ensures output matches the required [E{code}] {message} ({context}) structure.
Handles default omission gracefully ([E{code}] {message}) so missing context doesn't cause empty parentheses.


## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using "Closes #123" or "Fixes #123" format -->
Closes #

## Changes Made
<!-- List the specific changes made in this PR -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No tests required (documentation, CI/CD, etc.)

## Test Coverage
<!-- If applicable, mention test coverage changes -->
- [ ] Test coverage maintained or improved
- [ ] New tests added for new functionality

## Documentation
<!-- Mark the appropriate option with an "x" -->
- [ ] Documentation updated (if applicable)
- [ ] No documentation changes needed
- [ ] Documentation will be added in a follow-up PR

## Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
- [ ] No breaking changes
- [ ] Breaking changes (please describe):

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
