### PR TITLE
fix(session): use env.prng() for session nonce instead of sequential 0 (#292)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -792,11 +792,12 @@ impl AnchorKitContract {
         inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
 
         let now = env.ledger().timestamp();
+        let nonce: u64 = env.prng().u64();
         let session = Session {
             session_id,
             initiator: initiator.clone(),
             created_at: now,
-            nonce: 0,
+            nonce,
             operation_count: 0,
         };
         let sess_key = StorageKey::Session(session_id);
@@ -804,7 +805,7 @@ impl AnchorKitContract {
         env.storage().persistent().extend_ttl(&sess_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
         let snonce_key = StorageKey::SessionNonce(session_id);
-        env.storage().persistent().set(&snonce_key, &0u64);
+        env.storage().persistent().set(&snonce_key, &nonce);
         env.storage().persistent().extend_ttl(&snonce_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
         env.events().publish(

--- a/src/session_tests.rs
+++ b/src/session_tests.rs
@@ -72,6 +72,41 @@ mod session_tests {
     }
 
     #[test]
+    fn test_create_session_nonce_is_random_and_unique() {
+        let env = make_env();
+        setup_ledger(&env);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin);
+
+        let id0 = client.create_session(&user);
+        let id1 = client.create_session(&user);
+        let id2 = client.create_session(&user);
+
+        // IDs are still sequential
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+
+        let s0 = client.get_session(&id0);
+        let s1 = client.get_session(&id1);
+        let s2 = client.get_session(&id2);
+
+        // Nonces must not equal the session ID (no longer sequential 0,1,2)
+        assert_ne!(s0.nonce, id0, "nonce should not equal session_id");
+        assert_ne!(s1.nonce, id1, "nonce should not equal session_id");
+        assert_ne!(s2.nonce, id2, "nonce should not equal session_id");
+
+        // Nonces must be unique across sessions
+        assert_ne!(s0.nonce, s1.nonce, "nonces should be unique");
+        assert_ne!(s1.nonce, s2.nonce, "nonces should be unique");
+        assert_ne!(s0.nonce, s2.nonce, "nonces should be unique");
+    }
+
+    #[test]
     fn test_create_session_stores_initiator() {
         let env = make_env();
         setup_ledger(&env);


### PR DESCRIPTION
## Summary



`create_session` was setting `Session.nonce = 0` and storing `SessionNonce = 0` for every session. A predictable nonce weakens replay protection because an attacker can anticipate the value.

## Change

**`src/contract.rs`**

```rust
// Before
nonce: 0,
// ...
env.storage().persistent().set(&snonce_key, &0u64);

// After
let nonce: u64 = env.prng().u64();
// ...
nonce,
// ...
env.storage().persistent().set(&snonce_key, &nonce);
```

`env.prng().u64()` uses Soroban's built-in PRNG seeded from the ledger's randomness source, producing an unpredictable 64-bit value per session.

## Test

**`test_create_session_nonce_is_random_and_unique`** (new, in `session_tests.rs`):
- Creates 3 sessions and asserts IDs are still sequential (0, 1, 2) — `test_create_session_returns_sequential_ids` continues to pass unchanged
- Asserts each nonce ≠ its session ID (no longer the trivial sequential value)
- Asserts all three nonces are distinct from each other

## Acceptance criteria

Closes #292