### PR TITLE
fix: cache improvements — issues #258, #259, #260, #261

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -187,7 +187,7 @@ pub struct MetadataCache {
 #[derive(Clone)]
 pub struct CapabilitiesCache {
     pub toml_url: String,
-    pub capabilities: String,
+    pub capabilities: Vec<u32>,
     pub cached_at: u64,
     pub ttl_seconds: u64,
 }
@@ -1111,9 +1111,23 @@ impl AnchorKitContract {
 
     pub fn cache_metadata(env: Env, anchor: Address, metadata: AnchorMetadata, ttl_seconds: u64) {
         Self::require_admin(&env);
+        // Issue #259: skip write if metadata is unchanged
+        let key = StorageKey::MetadataCache(anchor.clone());
+        if let Some(existing) = env.storage().temporary().get::<_, MetadataCache>(&key) {
+            let m = &existing.metadata;
+            if m.anchor == metadata.anchor
+                && m.reputation_score == metadata.reputation_score
+                && m.liquidity_score == metadata.liquidity_score
+                && m.uptime_percentage == metadata.uptime_percentage
+                && m.total_volume == metadata.total_volume
+                && m.average_settlement_time == metadata.average_settlement_time
+                && m.is_active == metadata.is_active
+            {
+                return;
+            }
+        }
         let now = env.ledger().timestamp();
         let entry = MetadataCache { metadata, cached_at: now, ttl_seconds };
-        let key = (symbol_short!("METACACHE"), anchor.clone());
         let ledger_ttl = if ttl_seconds as u32 > MIN_TEMP_TTL { ttl_seconds as u32 } else { MIN_TEMP_TTL };
         env.storage().temporary().set(&key, &entry);
         env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
@@ -1141,9 +1155,18 @@ impl AnchorKitContract {
         entry.metadata
     }
 
+    /// Issue #260: returns seconds elapsed since the metadata cache entry was written,
+    /// or `None` if no cache entry exists for the anchor.
+    pub fn get_cache_age_seconds(env: Env, anchor: Address) -> Option<u64> {
+        let key = StorageKey::MetadataCache(anchor);
+        let entry: MetadataCache = env.storage().temporary().get(&key)?;
+        let now = env.ledger().timestamp();
+        Some(now.saturating_sub(entry.cached_at))
+    }
+
     pub fn refresh_metadata_cache(env: Env, anchor: Address) {
         Self::require_admin(&env);
-        let key = (symbol_short!("METACACHE"), anchor.clone());
+        let key = StorageKey::MetadataCache(anchor.clone());
         env.storage().temporary().remove(&key);
 
         // Issue #276: remove from CACHED_ANCHORS set
@@ -1172,7 +1195,7 @@ impl AnchorKitContract {
     // Capabilities cache
     // -----------------------------------------------------------------------
 
-    pub fn cache_capabilities(env: Env, anchor: Address, toml_url: String, capabilities: String, ttl_seconds: u64) {
+    pub fn cache_capabilities(env: Env, anchor: Address, toml_url: String, capabilities: Vec<u32>, ttl_seconds: u64) {
         Self::require_admin(&env);
         let now = env.ledger().timestamp();
         let entry = CapabilitiesCache { toml_url, capabilities, cached_at: now, ttl_seconds };
@@ -1197,6 +1220,40 @@ impl AnchorKitContract {
         Self::require_admin(&env);
         let key = StorageKey::CapabilitiesCache(anchor);
         env.storage().temporary().remove(&key);
+    }
+
+    /// Issue #258: admin-only emergency flush of all MetadataCache and CapabilitiesCache entries.
+    /// Emits a `CacheInvalidated` event with the count of cleared entries.
+    pub fn invalidate_all_caches(env: Env) {
+        Self::require_admin(&env);
+        let list_key = soroban_sdk::vec![&env, symbol_short!("CANCHORS")];
+        let anchors: Vec<Address> = env.storage().persistent()
+            .get::<_, Vec<Address>>(&list_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut count: u32 = 0;
+        for anchor in anchors.iter() {
+            let meta_key = StorageKey::MetadataCache(anchor.clone());
+            if env.storage().temporary().has(&meta_key) {
+                env.storage().temporary().remove(&meta_key);
+                count += 1;
+            }
+            let caps_key = StorageKey::CapabilitiesCache(anchor.clone());
+            if env.storage().temporary().has(&caps_key) {
+                env.storage().temporary().remove(&caps_key);
+                count += 1;
+            }
+        }
+
+        // Clear the anchor list
+        let empty: Vec<Address> = Vec::new(&env);
+        env.storage().persistent().set(&list_key, &empty);
+        env.storage().persistent().extend_ttl(&list_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("cache"), symbol_short!("invalidall")),
+            count,
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/metadata_cache_tests.rs
+++ b/src/metadata_cache_tests.rs
@@ -131,7 +131,9 @@ mod metadata_cache_tests {
         client.initialize(&admin);
 
         let toml_url = String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
-        let caps = String::from_str(&env, "{\"deposits\":true,\"withdrawals\":true}");
+        let mut caps = soroban_sdk::Vec::new(&env);
+        caps.push_back(1u32); // SERVICE_DEPOSITS
+        caps.push_back(2u32); // SERVICE_WITHDRAWALS
         client.cache_capabilities(&anchor, &toml_url, &caps, &3600u64);
 
         let cached = client.get_cached_capabilities(&anchor);
@@ -151,7 +153,8 @@ mod metadata_cache_tests {
         client.initialize(&admin);
 
         let toml_url = String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
-        let caps = String::from_str(&env, "{\"deposits\":true}");
+        let mut caps = soroban_sdk::Vec::new(&env);
+        caps.push_back(1u32);
         client.cache_capabilities(&anchor, &toml_url, &caps, &5u64);
 
         set_ledger(&env, 6);
@@ -171,13 +174,96 @@ mod metadata_cache_tests {
         client.initialize(&admin);
 
         let toml_url = String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
-        let caps = String::from_str(&env, "{\"deposits\":true}");
+        let mut caps = soroban_sdk::Vec::new(&env);
+        caps.push_back(1u32);
         client.cache_capabilities(&anchor, &toml_url, &caps, &3600u64);
 
         client.refresh_capabilities_cache(&anchor);
 
         let result = client.try_get_cached_capabilities(&anchor);
         assert!(result.is_err());
+    }
+
+    // Issue #259: cache_metadata skips write when data is unchanged
+    #[test]
+    fn test_cache_metadata_no_write_if_unchanged() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor = Address::generate(&env);
+        client.initialize(&admin);
+
+        let meta = sample_metadata(&env, &anchor);
+        client.cache_metadata(&anchor, &meta, &3600u64);
+
+        // Advance time and call again with identical metadata — cached_at should NOT update
+        set_ledger(&env, 100);
+        client.cache_metadata(&anchor, &meta, &3600u64);
+
+        // The cache entry should still have cached_at == 0 (original write)
+        // We verify by checking the age is >= 100 seconds
+        let age = client.get_cache_age_seconds(&anchor);
+        assert!(age.is_some());
+        assert!(age.unwrap() >= 100);
+    }
+
+    // Issue #260: get_cache_age_seconds returns None when no entry, Some(age) when cached
+    #[test]
+    fn test_get_cache_age_seconds() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor = Address::generate(&env);
+        client.initialize(&admin);
+
+        // No entry yet
+        assert!(client.get_cache_age_seconds(&anchor).is_none());
+
+        let meta = sample_metadata(&env, &anchor);
+        client.cache_metadata(&anchor, &meta, &3600u64);
+
+        // Advance 50 seconds
+        set_ledger(&env, 1050);
+        let age = client.get_cache_age_seconds(&anchor);
+        assert_eq!(age, Some(50));
+    }
+
+    // Issue #258: invalidate_all_caches removes all entries and emits event
+    #[test]
+    fn test_invalidate_all_caches() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor1 = Address::generate(&env);
+        let anchor2 = Address::generate(&env);
+        client.initialize(&admin);
+
+        let meta1 = sample_metadata(&env, &anchor1);
+        let meta2 = sample_metadata(&env, &anchor2);
+        client.cache_metadata(&anchor1, &meta1, &3600u64);
+        client.cache_metadata(&anchor2, &meta2, &3600u64);
+
+        // Both readable before flush
+        assert!(client.try_get_cached_metadata(&anchor1).is_ok());
+        assert!(client.try_get_cached_metadata(&anchor2).is_ok());
+
+        client.invalidate_all_caches();
+
+        // Both gone after flush
+        assert!(client.try_get_cached_metadata(&anchor1).is_err());
+        assert!(client.try_get_cached_metadata(&anchor2).is_err());
+
+        // Anchor list also cleared
+        assert_eq!(client.list_cached_anchors().len(), 0);
     }
 
     // Issue #276: list_cached_anchors returns all anchors with active cache entries

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,7 +204,7 @@ pub struct MetadataCache {
 #[derive(Clone)]
 pub struct CapabilitiesCache {
     pub toml_url: String,
-    pub capabilities: String,
+    pub capabilities: Vec<u32>,
     pub cached_at: u64,
     pub ttl_seconds: u64,
 }


### PR DESCRIPTION
## Summary

This PR resolves four related cache issues in the metadata/capabilities caching layer.

---

### #261 — Refactor `CapabilitiesCache.capabilities` from `String` to `Vec<u32>`

**Problem:** `capabilities` was stored as a raw JSON string, making access error-prone and non-type-safe.

**Fix:** Changed the field type to `Vec<u32>` (service type IDs) in both `contract.rs` and `types.rs`. Updated `cache_capabilities` signature and all callers/tests accordingly.

---

### #259 — Skip redundant write in `cache_metadata` when data is unchanged

**Problem:** `cache_metadata` always wrote to storage even when the incoming metadata was identical to the cached value, wasting Soroban write budget.

**Fix:** Added a field-by-field equality check before writing. If all fields match the existing entry, the function returns early without touching storage.

Also fixed a pre-existing key inconsistency: `cache_metadata` was writing with a raw tuple key `(symbol_short!("METACACHE"), anchor)` while `get_cached_metadata` and `refresh_metadata_cache` read/removed using `StorageKey::MetadataCache(anchor)`. All three now use `StorageKey::MetadataCache` consistently.

---

### #260 — Add `get_cache_age_seconds(anchor: Address) -> Option<u64>`

**Problem:** Callers had no way to determine how stale a cache entry was without reading `cached_at` and computing the difference themselves.

**Fix:** Added `get_cache_age_seconds` which returns `Some(now - cached_at)` if an entry exists, or `None` if not.

---

### #258 — Add `invalidate_all_caches()` admin-only emergency flush

**Problem:** No mechanism existed to flush all cached metadata at once during an incident.

**Fix:** Added `invalidate_all_caches()` (admin-only) that iterates the `CANCHORS` list, removes every `MetadataCache` and `CapabilitiesCache` entry, clears the anchor list, and emits a `CacheInvalidated` event with the count of cleared entries.

---

## Files Changed

- `src/contract.rs` — all four fixes
- `src/types.rs` — `CapabilitiesCache.capabilities: Vec<u32>`
- `src/metadata_cache_tests.rs` — updated existing tests + 4 new tests

## Tests

New tests added:
- `test_cache_metadata_no_write_if_unchanged` (#259)
- `test_get_cache_age_seconds` (#260)
- `test_invalidate_all_caches` (#258)
- Updated `test_cache_capabilities`, `test_capabilities_expiration`, `test_refresh_capabilities` (#261)

Closes #258
closes #259
closes #260 
closes #261