### PR TITLE
fix: add TransactionState::Unknown variant for unrecognized strings

### DIFF
--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -9,6 +9,8 @@ pub enum TransactionState {
     InProgress = 2,
     Completed = 3,
     Failed = 4,
+    /// Unrecognized state string from a future or unknown protocol version
+    Unknown = 5,
 }
 
 impl TransactionState {
@@ -18,6 +20,7 @@ impl TransactionState {
             TransactionState::InProgress => "in_progress",
             TransactionState::Completed => "completed",
             TransactionState::Failed => "failed",
+            TransactionState::Unknown => "unknown",
         }
     }
 
@@ -27,7 +30,7 @@ impl TransactionState {
             "in_progress" => Some(TransactionState::InProgress),
             "completed" => Some(TransactionState::Completed),
             "failed" => Some(TransactionState::Failed),
-            _ => None,
+            _ => Some(TransactionState::Unknown),
         }
     }
 }

--- a/src/transaction_state_tracker_tests.rs
+++ b/src/transaction_state_tracker_tests.rs
@@ -36,7 +36,15 @@ mod transaction_state_tracker_tests {
             TransactionState::from_str("failed"),
             Some(TransactionState::Failed)
         );
-        assert_eq!(TransactionState::from_str("unknown"), None);
+        // Unrecognized strings map to Unknown, not Error or None
+        assert_eq!(
+            TransactionState::from_str("some_future_state"),
+            Some(TransactionState::Unknown)
+        );
+        assert_eq!(
+            TransactionState::from_str("unknown"),
+            Some(TransactionState::Unknown)
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Bug Fixes: Transaction State Tracker & Clipboard Hook

## Summary

Four bug fixes across the Rust smart contract layer and the UI hooks layer.

---

## Changes

### fix/issue-297 — `TransactionState::Unknown` variant

`TransactionState::from_str` previously mapped unrecognized strings to `None`, conflating future protocol states with a missing value. Added a dedicated `Unknown = 5` variant so callers can distinguish "state I don't recognise" from a genuine error.

**Files changed:**
- `src/transaction_state_tracker.rs`
- `src/transaction_state_tracker_tests.rs`

Closes #297