### PR TITLE
fix: reset copied state after 2s with useEffect cleanup in useCopyToC…

### DIFF
--- a/ui/hooks/useCopyToClipboard.test.ts
+++ b/ui/hooks/useCopyToClipboard.test.ts
@@ -54,6 +54,29 @@ describe('useCopyToClipboard', () => {
     });
   });
 
+  it('should clear the reset timer on unmount (useEffect cleanup)', async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const { result, unmount } = renderHook(() => useCopyToClipboard({ successDuration: 2000 }));
+
+    await act(async () => {
+      await result.current.copy('test');
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    // Unmount before timer fires — should not cause state-update-on-unmounted-component warnings
+    act(() => {
+      unmount();
+    });
+
+    // Advancing time after unmount should not throw
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+    }).not.toThrow();
+  });
+
   it('should call onSuccess callback', async () => {
     mockWriteText.mockResolvedValue(undefined);
     const onSuccess = jest.fn();

--- a/ui/hooks/useCopyToClipboard.ts
+++ b/ui/hooks/useCopyToClipboard.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 export interface CopyToClipboardOptions {
   /**
@@ -63,6 +63,21 @@ export function useCopyToClipboard(
 
   const [copiedText, setCopiedText] = useState<string | null>(null);
   const [isCopied, setIsCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset isCopied after successDuration whenever it becomes true
+  useEffect(() => {
+    if (!isCopied) return;
+    timerRef.current = setTimeout(() => {
+      setIsCopied(false);
+    }, successDuration);
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [isCopied, successDuration]);
 
   const copy = useCallback(
     async (text: string): Promise<boolean> => {
@@ -79,12 +94,6 @@ export function useCopyToClipboard(
         setCopiedText(text);
         setIsCopied(true);
         onSuccess?.();
-
-        // Reset copied state after duration
-        setTimeout(() => {
-          setIsCopied(false);
-        }, successDuration);
-
         return true;
       } catch (err) {
         const error = err instanceof Error ? err : new Error('Failed to copy');
@@ -93,7 +102,7 @@ export function useCopyToClipboard(
         return false;
       }
     },
-    [successDuration, onSuccess, onError]
+    [onSuccess, onError]
   );
 
   const reset = useCallback(() => {


### PR DESCRIPTION
---

### fix/issue-288 — `useCopyToClipboard` reset timer with `useEffect` cleanup

The copy button stayed in "copied" state permanently after first use because the `setTimeout` inside the `copy` callback was never cancelled. Replaced it with a `useEffect` that fires when `isCopied` becomes `true` and clears the timer on cleanup, preventing stale timers and state updates on unmounted components. `successDuration` option (default `2000ms`) remains configurable.

**Files changed:**
- `ui/hooks/useCopyToClipboard.ts`
- `ui/hooks/useCopyToClipboard.test.ts`

Closes #288

---