### PR TITLE
fix: require admin auth for clear_cache in production mode

### DIFF
--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -206,13 +206,17 @@ impl TransactionStateTracker {
         }
     }
 
-    /// Clear all cached transactions (dev mode only)
-    pub fn clear_cache(&mut self) -> Result<(), String> {
+    /// Clear all cached transactions.
+    /// In dev mode: always allowed.
+    /// In production mode: requires admin authorization.
+    pub fn clear_cache(&mut self, admin: &Address, env: &Env) -> Result<(), String> {
         if self.is_dev_mode {
             self.cache = alloc::vec::Vec::new();
             Ok(())
         } else {
-            Err(String::from_str(&Env::default(), "Cannot clear cache in production mode"))
+            admin.require_auth();
+            self.cache = alloc::vec::Vec::new();
+            Ok(())
         }
     }
 
@@ -353,7 +357,7 @@ mod tests {
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
-        let clear_result = tracker.clear_cache();
+        let clear_result = tracker.clear_cache(&initiator, &env);
 
         assert!(clear_result.is_ok());
         assert_eq!(tracker.cache_size(), 0);

--- a/src/transaction_state_tracker_tests.rs
+++ b/src/transaction_state_tracker_tests.rs
@@ -177,9 +177,23 @@ mod transaction_state_tracker_tests {
         tracker.create_transaction(2, initiator.clone(), &env).ok();
         assert_eq!(tracker.cache_size(), 2);
 
-        let clear_result = tracker.clear_cache();
+        let clear_result = tracker.clear_cache(&initiator, &env);
         assert!(clear_result.is_ok());
         assert_eq!(tracker.cache_size(), 0);
+    }
+
+    #[test]
+    fn test_clear_cache_production_requires_admin() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(false);
+        let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        // In production mode, clear_cache requires admin auth.
+        // Calling without mock auth should panic (require_auth panics when not authorized).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tracker.clear_cache(&admin, &env)
+        }));
+        assert!(result.is_err(), "Expected panic due to missing admin auth in production mode");
     }
 
     #[test]


### PR DESCRIPTION
### fix/issue-298 — Admin auth required for `clear_cache` in production

`clear_cache` was gated only by `is_dev_mode`, which may not be set correctly in all deployments. Updated the signature to `clear_cache(admin: &Address, env: &Env)` and added `admin.require_auth()` in the production path. Dev mode remains unrestricted.

**Files changed:**
- `src/transaction_state_tracker.rs`
- `src/transaction_state_tracker_tests.rs`

Closes #298
