### PR TITLE
feat: add Makefile with standard targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build test lint fmt clean deploy-testnet help
+
+## build: Build the contract in release mode
+build:
+	cargo build --release
+
+## test: Run all tests
+test:
+	cargo test
+
+## lint: Run clippy with warnings as errors
+lint:
+	cargo clippy -- -D warnings
+
+## fmt: Format code with rustfmt
+fmt:
+	cargo fmt
+
+## clean: Remove build artifacts
+clean:
+	cargo clean
+
+## deploy-testnet: Deploy contract to Stellar testnet
+deploy-testnet:
+	soroban contract deploy \
+		--wasm target/wasm32-unknown-unknown/release/anchor_kit.wasm \
+		--network testnet
+
+## help: Show this help message
+help:
+	@grep -E '^## ' Makefile | sed 's/## //'

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to AnchorKit! This document provides
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
 - [Development Environment Setup](#development-environment-setup)
+- [Makefile Shortcuts](#makefile-shortcuts)
 - [Running Tests](#running-tests)
 - [Code Style Guidelines](#code-style-guidelines)
 - [Branch Naming Conventions](#branch-naming-conventions)
@@ -83,6 +84,22 @@ The UI components are built with React and TypeScript.
    node --version
    npm --version
    ```
+
+## Makefile Shortcuts
+
+A `Makefile` is provided at the project root for common tasks:
+
+```bash
+make build          # cargo build --release
+make test           # cargo test
+make lint           # cargo clippy -- -D warnings
+make fmt            # cargo fmt
+make clean          # cargo clean
+make deploy-testnet # deploy to Stellar testnet
+make help           # list all targets
+```
+
+> **Note**: Requires `make` (available by default on Linux and macOS).
 
 ## Running Tests
 


### PR DESCRIPTION
Closes #331

## Changes
- Added `Makefile` at project root with targets: `build`, `test`, `lint`, `fmt`, `clean`, `deploy-testnet`, `help`
- Updated `docs/guides/CONTRIBUTING.md` with Makefile Shortcuts section and ToC entry

## Targets
| Target | Command |
|---|---|
| `make build` | `cargo build --release` |
| `make test` | `cargo test` |
| `make lint` | `cargo clippy -- -D warnings` |
| `make fmt` | `cargo fmt` |
| `make clean` | `cargo clean` |
| `make deploy-testnet` | deploy via soroban CLI to testnet |
| `make help` | list all targets |

Works on Linux and macOS.