### PR TITLE
fix: resolve contract issues #428 #429 #430 #431

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -133,6 +133,8 @@ const SPAN_TTL: u32 = 17_280;
 const INSTANCE_TTL: u32 = 518_400;
 /// Session TTL in seconds (~24 hours).
 const SESSION_TTL: u64 = 86_400;
+/// Session storage TTL in ledgers (~24 hours at 5s/ledger).
+const SESSION_LEDGER_TTL: u32 = 17_280;
 
 fn pending_admin_key(env: &Env) -> soroban_sdk::Vec<soroban_sdk::Symbol> {
     soroban_sdk::vec![env, symbol_short!("PADMIN")]
@@ -604,6 +606,31 @@ impl AnchorKitContract {
             panic_with_error!(&env, ErrorCode::ServicesNotConfigured);
         }
 
+        let inst = env.storage().instance();
+        let qcnt_key = key_quote_counter(&env);
+        let next: u64 = inst.get(&qcnt_key).unwrap_or(0u64) + 1;
+        inst.set(&qcnt_key, &next);
+        inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+
+        let quote = Quote {
+            quote_id: next,
+            anchor: anchor.clone(),
+            base_asset: from_asset,
+            quote_asset: to_asset,
+            rate: amount,
+            fee_percentage: fee_bps,
+            minimum_amount: min_amount,
+            maximum_amount: max_amount,
+            valid_until: expires_at,
+        };
+        let q_key = StorageKey::Quote(anchor.clone(), next);
+        env.storage().persistent().set(&q_key, &quote);
+        env.storage().persistent().extend_ttl(&q_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let lq_key = StorageKey::LatestQuote(anchor.clone());
+        env.storage().persistent().set(&lq_key, &next);
+        env.storage().persistent().extend_ttl(&lq_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
         let now = env.ledger().timestamp();
         Self::store_span(&env, &request_id, String::from_str(&env, "submit_quote"), anchor, now, String::from_str(&env, "success"));
     }
@@ -703,11 +730,11 @@ impl AnchorKitContract {
         };
         let sess_key = StorageKey::Session(session_id);
         env.storage().persistent().set(&sess_key, &session);
-        env.storage().persistent().extend_ttl(&sess_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.storage().persistent().extend_ttl(&sess_key, SESSION_LEDGER_TTL, SESSION_LEDGER_TTL);
 
         let snonce_key = StorageKey::SessionNonce(session_id);
         env.storage().persistent().set(&snonce_key, &nonce);
-        env.storage().persistent().extend_ttl(&snonce_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.storage().persistent().extend_ttl(&snonce_key, SESSION_LEDGER_TTL, SESSION_LEDGER_TTL);
 
         env.events().publish(
             (symbol_short!("session"), symbol_short!("created"), session_id),
@@ -901,9 +928,10 @@ impl AnchorKitContract {
         id
     }
 
-    pub fn register_attestor_with_session(env: Env, session_id: u64, attestor: Address) {
+    pub fn register_attestor_with_session(env: Env, session_id: u64, attestor: Address, sep10_token: String, sep10_issuer: Address) {
         Self::check_session_expiry(&env, session_id);
         Self::require_admin(&env);
+        Self::verify_sep10_token_matches_attestor(&env, &sep10_token, &sep10_issuer, &attestor);
         let key = StorageKey::Attestor(attestor.clone());
         if env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorAlreadyRegistered);
@@ -1045,16 +1073,18 @@ impl AnchorKitContract {
         result
     }
 
-    pub fn get_session_operation_count(env: Env, session_id: u64) -> u64 {
-        Self::check_session_expiry(&env, session_id);
+    pub fn get_session_operation_count(env: Env, session_id: u64) -> Option<u64> {
         let sess_key = StorageKey::Session(session_id);
         if !env.storage().persistent().has(&sess_key) {
-            panic_with_error!(&env, ErrorCode::ValidationError);
+            return None;
         }
-        env.storage()
-            .persistent()
-            .get::<_, u64>(&StorageKey::SessionOpCount(session_id))
-            .unwrap_or(0)
+        Self::check_session_expiry(&env, session_id);
+        Some(
+            env.storage()
+                .persistent()
+                .get::<_, u64>(&StorageKey::SessionOpCount(session_id))
+                .unwrap_or(0),
+        )
     }
 
     // -----------------------------------------------------------------------

--- a/src/session_tests.rs
+++ b/src/session_tests.rs
@@ -10,7 +10,7 @@ mod session_tests {
     use rand::rngs::OsRng;
 
     use crate::contract::{AnchorKitContract, AnchorKitContractClient};
-    use crate::sep10_test_util::{register_attestor_with_sep10, sign_payload};
+    use crate::sep10_test_util::{build_sep10_jwt, register_attestor_with_sep10, sign_payload};
 
     fn make_env() -> Env {
         let env = Env::default();
@@ -45,6 +45,30 @@ mod session_tests {
             b.push_back(x);
         }
         b
+    }
+
+    /// Register an attestor via `register_attestor_with_session`, generating a valid SEP-10 token.
+    fn register_with_session(
+        env: &Env,
+        client: &AnchorKitContractClient,
+        session_id: u64,
+        attestor: &Address,
+        sk: &SigningKey,
+    ) {
+        let issuer = attestor.clone();
+        let pk = soroban_sdk::Bytes::from_slice(env, sk.verifying_key().as_bytes());
+        client.set_sep10_jwt_verifying_key(&issuer, &pk);
+
+        let sub = attestor.to_string();
+        let mut buf = [0u8; 128];
+        let len = sub.len() as usize;
+        let final_len = if len > 128 { 128 } else { len };
+        sub.copy_into_slice(&mut buf[..final_len]);
+        let sub_str = core::str::from_utf8(&buf[..final_len]).unwrap_or("");
+        let exp = env.ledger().timestamp().saturating_add(86_400);
+        let jwt = build_sep10_jwt(sk, sub_str, exp);
+        let token = String::from_str(env, jwt.as_str());
+        client.register_attestor_with_session(&session_id, attestor, &token, &issuer);
     }
 
     // -----------------------------------------------------------------------
@@ -120,11 +144,10 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        assert_eq!(client.get_session_operation_count(&session_id), 0);
+        assert_eq!(client.get_session_operation_count(&session_id).unwrap(), 0);
     }
     #[test]
-    #[should_panic(expected = "HostError: Error(Contract, #15)")]
-    fn test_get_session_operation_count_panics_for_non_existent_session() {
+    fn test_get_session_operation_count_returns_none_for_non_existent_session() {
         let env = make_env();
         setup_ledger(&env);
         let contract_id = env.register_contract(None, AnchorKitContract);
@@ -133,7 +156,7 @@ mod session_tests {
         let admin = Address::generate(&env);
         client.initialize(&admin, &100_u64, &None);
 
-        client.get_session_operation_count(&999u64);
+        assert!(client.get_session_operation_count(&999u64).is_none());
     }
 
     #[test]
@@ -149,9 +172,10 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        client.register_attestor_with_session(&session_id, &attestor);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
 
-        assert_eq!(client.get_session_operation_count(&session_id), 1);
+        assert_eq!(client.get_session_operation_count(&session_id).unwrap(), 1);
     }
 
     #[test]
@@ -181,7 +205,7 @@ mod session_tests {
             &sign_payload(&env, &sk, &p),
         );
 
-        assert_eq!(client.get_session_operation_count(&session_id), 1);
+        assert_eq!(client.get_session_operation_count(&session_id).unwrap(), 1);
     }
 
     #[test]
@@ -234,7 +258,8 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        client.register_attestor_with_session(&session_id, &attestor);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
 
         assert!(client.is_attestor(&attestor));
     }
@@ -252,7 +277,8 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        client.register_attestor_with_session(&session_id, &attestor);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
 
         let log = client.get_audit_log(&0u64);
         assert_eq!(log.log_id, 0);
@@ -279,7 +305,8 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        client.register_attestor_with_session(&session_id, &attestor);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
         client.revoke_attestor_with_session(&session_id, &attestor);
 
         assert!(!client.is_attestor(&attestor));
@@ -298,7 +325,8 @@ mod session_tests {
         client.initialize(&admin, &100_u64, &None);
 
         let session_id = client.create_session(&user);
-        client.register_attestor_with_session(&session_id, &attestor);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
         client.revoke_attestor_with_session(&session_id, &attestor);
 
         // log_id 0 = register, log_id 1 = revoke
@@ -329,9 +357,7 @@ mod session_tests {
         let session_id = client.create_session(&attestor);
         // Set Sep10 key so signature verification works, then register via session (writes audit log)
         let sk = SigningKey::generate(&mut OsRng);
-        let pk = soroban_sdk::Bytes::from_slice(&env, sk.verifying_key().as_bytes());
-        client.set_sep10_jwt_verifying_key(&attestor, &pk);
-        client.register_attestor_with_session(&session_id, &attestor);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
         let p = payload(&env, 0x01);
         client.submit_attestation_with_session(
             &session_id,
@@ -373,9 +399,7 @@ mod session_tests {
 
         // Step 2: set Sep10 key, then register via session (writes audit log_id=0 "register")
         let sk = SigningKey::generate(&mut OsRng);
-        let pk = soroban_sdk::Bytes::from_slice(&env, sk.verifying_key().as_bytes());
-        client.set_sep10_jwt_verifying_key(&attestor, &pk);
-        client.register_attestor_with_session(&session_id, &attestor);
+        register_with_session(&env, &client, session_id, &attestor, &sk);
         assert!(client.is_attestor(&attestor));
 
         // Step 3: two attestations
@@ -401,7 +425,7 @@ mod session_tests {
         assert_eq!(id1, 1);
 
         // Step 4: verify operation count = 3 (register + 2 attests)
-        assert_eq!(client.get_session_operation_count(&session_id), 3);
+        assert_eq!(client.get_session_operation_count(&session_id).unwrap(), 3);
 
         // Step 5: verify audit logs
         let log0 = client.get_audit_log(&0u64);
@@ -433,20 +457,17 @@ mod session_tests {
 
         let mut csprng = OsRng;
         let signing_key = SigningKey::generate(&mut csprng);
+        let sk2 = SigningKey::generate(&mut csprng);
         let attestor = Address::generate(&env);
         let attestor2 = Address::generate(&env);
         let attestor3 = Address::generate(&env);
 
-        // Set Sep10 key for attestor so signature verification works
-        let pk = soroban_sdk::Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
-        client.set_sep10_jwt_verifying_key(&attestor, &pk);
-
         // Write log_id=0 via register_attestor_with_session
         let session_id = client.create_session(&attestor);
-        client.register_attestor_with_session(&session_id, &attestor);
+        register_with_session(&env, &client, session_id, &attestor, &signing_key);
 
         // Write log_id=1 via register_attestor_with_session for attestor2
-        client.register_attestor_with_session(&session_id, &attestor2);
+        register_with_session(&env, &client, session_id, &attestor2, &sk2);
 
         // log_id=0 still accessible (live=[0,1], count=2 == max_size, no prune yet).
         let log0 = client.get_audit_log(&0u64);
@@ -477,17 +498,14 @@ mod session_tests {
 
         let mut csprng = OsRng;
         let signing_key = SigningKey::generate(&mut csprng);
+        let sk2 = SigningKey::generate(&mut csprng);
         let attestor = Address::generate(&env);
         let attestor2 = Address::generate(&env);
 
-        // Set Sep10 key for attestor so signature verification works
-        let pk = soroban_sdk::Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
-        client.set_sep10_jwt_verifying_key(&attestor, &pk);
-
         // Write log_id=0 and log_id=1 via register_attestor_with_session
         let session_id = client.create_session(&attestor);
-        client.register_attestor_with_session(&session_id, &attestor);
-        client.register_attestor_with_session(&session_id, &attestor2);
+        register_with_session(&env, &client, session_id, &attestor, &signing_key);
+        register_with_session(&env, &client, session_id, &attestor2, &sk2);
 
         // Write log_id=2 → prunes log_id=0.
         let ph = payload(&env, 0xCD);


### PR DESCRIPTION
## Summary


### #428 — `register_attestor_with_session` does not verify SEP-10 token

**Problem:** Unlike `register_attestor`, the session-aware variant accepted any address without proof of ownership.

**Fix:** Added `sep10_token: String` and `sep10_issuer: Address` parameters and call `verify_sep10_token_matches_attestor` before writing to storage — identical to the behaviour of `register_attestor`.

closes #428 
---

### #429 — `quote_with_request_id` stores no Quote record on-chain

**Problem:** The function validated services and wrote a tracing span but never persisted a `Quote` struct, making the request-ID variant useless for subsequent `get_quote` calls.

**Fix:** Increments the quote counter and persists `StorageKey::Quote` and `StorageKey::LatestQuote` exactly as `submit_quote` does, mapping the function's parameters to the `Quote` struct fields (`from_asset`→`base_asset`, `to_asset`→`quote_asset`, `amount`→`rate`, `fee_bps`→`fee_percentage`, `min_amount`→`minimum_amount`, `max_amount`→`maximum_amount`, `expires_at`→`valid_until`).

closes #429 
---

### #430 — Session storage TTL uses `PERSISTENT_TTL` (90 days) instead of matching the 24-hour session lifetime

**Problem:** `create_session` set `expires_at = now + SESSION_TTL` (86 400 seconds = 24 h) but stored the session key with `PERSISTENT_TTL = 1_555_200 ledgers` (~90 days), leaving expired sessions in storage far longer than necessary and wasting rent.

**Fix:** Added `SESSION_LEDGER_TTL: u32 = 17_280` (86 400 s ÷ 5 s/ledger = 17 280 ledgers ≈ 24 h) and used it for the `Session` and `SessionNonce` storage keys in `create_session`.

closes #430 
---

### #431 — `get_session_operation_count` panics on a missing session instead of returning `Option`

**Problem:** Callers could not distinguish a missing session from a contract bug; the only signal was a `ValidationError` panic.

**Fix:** Changed the return type to `Option<u64>`. Returns `None` when the session key is absent; returns `Some(count)` (defaulting to 0 if the op-count key is not yet written) for a live session.

closes #431 
---

## Test changes (`src/session_tests.rs`)

- Replaced `test_get_session_operation_count_panics_for_non_existent_session` (`#[should_panic]`) with `test_get_session_operation_count_returns_none_for_non_existent_session` that asserts `is_none()`.
- Added `register_with_session` helper that generates a valid SEP-10 JWT and calls the updated `register_attestor_with_session` signature.
- Updated all `register_attestor_with_session` call sites to use the helper.
- Updated all `get_session_operation_count` assertions to `.unwrap()` the returned `Option`.

---

## Files changed

| File | Change |
|------|--------|
| `src/contract.rs` | All four fixes |
| `src/session_tests.rs` | Updated tests to match new signatures |
