### PR TITLE
fix: resolve contract issues #463 #464

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1234,11 +1234,21 @@ impl AnchorKitContract {
             / 100;
 
         // Ensure score is capped at 100
-        if health_score > 100 {
-            100
-        } else {
-            health_score
+        let final_score = if health_score > 100 { 100 } else { health_score };
+
+        // Issue #464: enforce configurable minimum acceptable health score.
+        // When key_health_threshold is set (> 0), reject anchors whose computed
+        // score falls below it so callers cannot route to unhealthy anchors.
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&key_health_threshold(&env))
+            .unwrap_or(0u32);
+        if threshold > 0 && final_score < threshold {
+            panic_with_error!(&env, ErrorCode::ValidationError);
         }
+
+        final_score
     }
 
 
@@ -1295,7 +1305,8 @@ impl AnchorKitContract {
         env.storage().temporary().remove(&key);
     }
 
-    /// Issue #258: admin-only emergency flush of all MetadataCache and CapabilitiesCache entries.
+    /// Issue #258/#463: admin-only emergency flush of all MetadataCache,
+    /// CapabilitiesCache, and TomlCache entries for every tracked anchor.
     /// Emits a `CacheInvalidated` event with the count of cleared entries.
     pub fn invalidate_all_caches(env: Env) {
         Self::require_admin(&env);
@@ -1314,6 +1325,12 @@ impl AnchorKitContract {
             let caps_key = StorageKey::CapabilitiesCache(anchor.clone());
             if env.storage().temporary().has(&caps_key) {
                 env.storage().temporary().remove(&caps_key);
+                count += 1;
+            }
+            // Issue #463: also flush cached stellar.toml entries
+            let toml_key = StorageKey::TomlCache(anchor.clone());
+            if env.storage().temporary().has(&toml_key) {
+                env.storage().temporary().remove(&toml_key);
                 count += 1;
             }
         }


### PR DESCRIPTION
## Summary

- **#463** `invalidate_all_caches`: also removes `StorageKey::TomlCache(anchor)` for every tracked anchor so emergency flushes clear stale TOML data (previously only `MetadataCache` and `CapabilitiesCache` entries were cleared).
- **#464** `get_anchor_health_score`: reads `key_health_threshold` and panics with `ValidationError` when the computed score is below the configured minimum, so the stored threshold now has a documented effect on the routing/health path.
- **#465** & **#466**: verified already wired in the current `main` — `update_health_status` deactivates the anchor and emits `AnchorDeactivated` once `failure_count >= key_health_threshold`, and `check_session_expiry` emits `SessionExpired` before panicking. No code change required for these two.

## Test plan

- [ ] `cargo build` (no toolchain available in the dev environment used for this change — please run locally)
- [ ] `cargo test --lib` — exercise `test_invalidate_all_caches`, `test_auto_deactivation`, and `anchor_health_score_tests::*`
- [ ] Add a regression test that caches a TOML via `fetch_anchor_info` then asserts `get_anchor_toml` errors after `invalidate_all_caches`
- [ ] Add a regression test that sets a non-zero health threshold and asserts `get_anchor_health_score` panics for a low-scoring anchor

Closes #463 
Closes #464 
Closes #465 
Closes #466 