### PR TITLE
fix: resolve contract issues #467 #468 #469 #470

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -127,9 +127,20 @@ struct AttestorRevoked(Address);
 
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
+//
+// Stellar/Soroban ledgers close roughly every 5 seconds on mainnet and the
+// public testnet, so the ledger counts below are sized as follows:
+//   PERSISTENT_TTL = 1_555_200 ledgers ≈ 7_776_000 s ≈ 90 days
+//   INSTANCE_TTL   =   518_400 ledgers ≈ 2_592_000 s ≈ 30 days
+//   SPAN_TTL       =    17_280 ledgers ≈    86_400 s ≈ 24 hours
+// If you deploy against a network with a different ledger close time, scale
+// these constants accordingly (or override them per-network in a fork).
 // ---------------------------------------------------------------------------
+/// Persistent-storage TTL: ~90 days at 5 s/ledger.
 const PERSISTENT_TTL: u32 = 1_555_200;
+/// Temporary-storage TTL for tracing spans: ~24 hours at 5 s/ledger.
 const SPAN_TTL: u32 = 17_280;
+/// Instance-storage TTL: ~30 days at 5 s/ledger.
 const INSTANCE_TTL: u32 = 518_400;
 /// Session TTL in seconds (~24 hours).
 const SESSION_TTL: u64 = 86_400;
@@ -515,6 +526,9 @@ impl AnchorKitContract {
     ) -> u64 {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
+        if let Err(e) = crate::rate_limiter::RateLimiter::check_and_increment(&env, &issuer) {
+            panic_with_error!(&env, e);
+        }
         Self::check_timestamp(&env, timestamp);
         Self::verify_attestation_signature(&env, &issuer, &payload_hash, &signature);
 
@@ -552,6 +566,9 @@ impl AnchorKitContract {
     ) -> u64 {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
+        if let Err(e) = crate::rate_limiter::RateLimiter::check_and_increment(&env, &issuer) {
+            panic_with_error!(&env, e);
+        }
         Self::check_timestamp(&env, timestamp);
         Self::verify_attestation_signature(&env, &issuer, &payload_hash, &signature);
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -73,3 +73,10 @@ pub struct RateLimitReset {
     pub admin: Address,
     pub timestamp: u64,
 }
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RateLimitWindowReset {
+    pub attestor: Address,
+    pub window_start: u64,
+}

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -5,7 +5,8 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 use crate::errors::ErrorCode;
-use crate::events::RateLimitReset;
+use crate::events::{RateLimitReset, RateLimitWindowReset};
+use crate::storage::StorageKey;
 
 /// Rate limit configuration stored in contract storage
 #[contracttype]
@@ -29,13 +30,6 @@ pub struct RateLimitState {
     pub total_requests: u64,
 }
 
-#[contracttype]
-#[derive(Clone)]
-pub struct RateLimitWindowReset {
-    pub attestor: Address,
-    pub window_start: u64,
-}
-
 /// Rate limiter for attestation submissions
 #[contract]
 pub struct RateLimiter;
@@ -44,7 +38,7 @@ pub struct RateLimiter;
 impl RateLimiter {
     /// Get the current rate limit state for an attestor
     pub fn get_state(env: Env, attestor: Address) -> RateLimitState {
-        let state_key = Self::get_state_key(&env, &attestor);
+        let state_key = StorageKey::RateLimitState(attestor.clone());
         env.storage().persistent().get::<_, RateLimitState>(&state_key)
             .unwrap_or(RateLimitState {
                 submission_count: 0,
@@ -66,13 +60,21 @@ impl RateLimiter {
 
 impl RateLimiter {
     /// Check if an attestor can submit an attestation and increment their counter.
+    ///
+    /// Rate limiting is opt-in: if no global `RateLimitConfig` has been written
+    /// to storage and no per-attestor override exists for `attestor`, the check
+    /// is skipped entirely and `Ok(())` is returned without touching state.
+    /// Admins activate enforcement by calling `update_config`.
     pub fn check_and_increment(
         env: &Env,
         attestor: &Address,
     ) -> Result<(), ErrorCode> {
+        if !Self::is_configured(env, attestor) {
+            return Ok(());
+        }
         let config = Self::get_effective_config(env.clone(), attestor.clone());
         let current_ledger = env.ledger().sequence();
-        let state_key = Self::get_state_key(env, attestor);
+        let state_key = StorageKey::RateLimitState(attestor.clone());
 
         let mut state = env.storage().persistent().get::<_, RateLimitState>(&state_key)
             .unwrap_or(RateLimitState {
@@ -116,7 +118,7 @@ impl RateLimiter {
     ) -> Result<(), ErrorCode> {
         match attestor {
             Some(addr) => {
-                let key = Self::get_attestor_config_key(env, addr);
+                let key = StorageKey::RateLimitOverride(addr.clone());
                 env.storage().persistent().set(&key, &config);
             }
             None => {
@@ -129,9 +131,20 @@ impl RateLimiter {
 
     /// Get the effective config for an attestor: per-attestor override if set, else global.
     pub fn get_effective_config(env: Env, attestor: Address) -> RateLimitConfig {
-        let key = Self::get_attestor_config_key(&env, &attestor);
+        let key = StorageKey::RateLimitOverride(attestor.clone());
         env.storage().persistent().get::<_, RateLimitConfig>(&key)
             .unwrap_or_else(|| Self::get_config(env.clone()))
+    }
+
+    /// Returns true if rate limiting has been explicitly configured — either via
+    /// a global config or a per-attestor override.
+    fn is_configured(env: &Env, attestor: &Address) -> bool {
+        let override_key = StorageKey::RateLimitOverride(attestor.clone());
+        if env.storage().persistent().has(&override_key) {
+            return true;
+        }
+        let global_key = Self::get_config_key(env);
+        env.storage().persistent().has(&global_key)
     }
 
     /// Reset the rate limit for a specified attestor (admin-only function).
@@ -157,7 +170,7 @@ impl RateLimiter {
         admin.require_auth();
 
         // Get current state to preserve total_requests
-        let state_key = Self::get_state_key(env, attestor);
+        let state_key = StorageKey::RateLimitState(attestor.clone());
         let current_state = env.storage().persistent().get::<_, RateLimitState>(&state_key)
             .unwrap_or(RateLimitState {
                 submission_count: 0,
@@ -192,30 +205,9 @@ impl RateLimiter {
         current_ledger.saturating_sub(window_start_ledger) >= window_length
     }
 
-    fn get_state_key(env: &Env, attestor: &Address) -> soroban_sdk::BytesN<32> {
-        let address_str = attestor.to_string();
-        let mut address_bytes = [0u8; 128];
-        let len = address_str.len() as usize;
-        let final_len = if len > 128 { 128 } else { len };
-        address_str.copy_into_slice(&mut address_bytes[..final_len]);
-        let bytes = soroban_sdk::Bytes::from_slice(env, &address_bytes[..final_len]);
-        env.crypto().sha256(&bytes).into()
-    }
-
     fn get_config_key(env: &Env) -> soroban_sdk::BytesN<32> {
         let config_key = *b"rate_limit_config_______________";
         soroban_sdk::BytesN::from_array(env, &config_key)
-    }
-
-    fn get_attestor_config_key(env: &Env, attestor: &Address) -> soroban_sdk::BytesN<32> {
-        let address_str = attestor.to_string();
-        let mut buf = [0u8; 56];
-        address_str.copy_into_slice(&mut buf);
-        let mut prefixed = [0u8; 57];
-        prefixed[0] = b'c';
-        prefixed[1..].copy_from_slice(&buf);
-        let bytes = soroban_sdk::Bytes::from_slice(env, &prefixed);
-        env.crypto().sha256(&bytes).into()
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -51,6 +51,10 @@ pub enum StorageKey {
     AnchorMeta(Address),
     /// Stellar.toml cache for an anchor (temporary).
     TomlCache(Address),
+    /// Per-attestor rate-limit state — submission count + window start (persistent).
+    RateLimitState(Address),
+    /// Per-attestor rate-limit configuration override (persistent).
+    RateLimitOverride(Address),
     // --- Instance-storage counters (stored as Vec<Symbol> keys) ---
     // These are kept as plain symbol_short! vecs because instance storage
     // requires a Vec<Symbol> key; they are defined as named constants below.


### PR DESCRIPTION
- #467 Document PERSISTENT_TTL/INSTANCE_TTL/SPAN_TTL in real-time units (≈90 d / 30 d / 24 h at 5 s/ledger) so operators can size them per network.
- #468 Wire RateLimiter::check_and_increment into submit_attestation and submit_with_request_id; propagate RateLimitExceeded via panic_with_error!. Rate limiting is opt-in: when no global config and no per-attestor override exist, the check is skipped, so existing deployments and tests are unaffected until an admin calls update_config.
- #469 Add StorageKey::RateLimitState(Address) and StorageKey::RateLimitOverride(Address) variants; replace the hand-rolled sha256 helpers (get_state_key, get_attestor_config_key) in rate_limiter.rs so the rate-limit storage layout is visible through the typed StorageKey enum.
- #470 Move RateLimitWindowReset event struct from rate_limiter.rs to events.rs alongside the other event types; rate_limiter.rs now imports it.

Closes #467 
Closes #468 
Closes #469 
Closes #470 