### PR TITLE
fix(#440): add issuer_revoked flag to Attestation on attestor revocation

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -409,6 +409,10 @@ impl AnchorKitContract {
             panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
         }
         env.storage().persistent().remove(&key);
+        // Mark the attestor as revoked so historical attestations surface issuer_revoked=true.
+        let revoked_key = StorageKey::AttestorRevoked(attestor.clone());
+        env.storage().persistent().set(&revoked_key, &true);
+        env.storage().persistent().extend_ttl(&revoked_key, PERSISTENT_TTL, PERSISTENT_TTL);
         env.events().publish(
             (symbol_short!("attestor"), symbol_short!("revoked")),
             AttestorRevoked(attestor),
@@ -667,9 +671,14 @@ impl AnchorKitContract {
     // -----------------------------------------------------------------------
 
     pub fn get_attestation(env: Env, id: u64) -> Option<Attestation> {
-        env.storage()
+        let mut attestation = env.storage()
             .persistent()
-            .get::<_, Attestation>(&StorageKey::Attest(id))
+            .get::<_, Attestation>(&StorageKey::Attest(id))?;
+        // Reflect current revocation status without rewriting every stored attestation.
+        if env.storage().persistent().has(&StorageKey::AttestorRevoked(attestation.issuer.clone())) {
+            attestation.issuer_revoked = true;
+        }
+        Some(attestation)
     }
 
     pub fn list_attestations(env: Env, subject: Address, offset: u64, limit: u32) -> Vec<Attestation> {
@@ -693,7 +702,10 @@ impl AnchorKitContract {
             let index_key = StorageKey::SubjectAttestation(subject.clone(), i);
             if let Some(attestation_id) = env.storage().persistent().get::<_, u64>(&index_key) {
                 let main_key = StorageKey::Attest(attestation_id);
-                if let Some(attestation) = env.storage().persistent().get::<_, Attestation>(&main_key) {
+                if let Some(mut attestation) = env.storage().persistent().get::<_, Attestation>(&main_key) {
+                    if env.storage().persistent().has(&StorageKey::AttestorRevoked(attestation.issuer.clone())) {
+                        attestation.issuer_revoked = true;
+                    }
                     results.push_back(attestation);
                 }
             }
@@ -1006,6 +1018,10 @@ impl AnchorKitContract {
             panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
         }
         env.storage().persistent().remove(&key);
+        // Mark the attestor as revoked so historical attestations surface issuer_revoked=true.
+        let revoked_key = StorageKey::AttestorRevoked(attestor.clone());
+        env.storage().persistent().set(&revoked_key, &true);
+        env.storage().persistent().extend_ttl(&revoked_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
         let sopcnt_key = StorageKey::SessionOpCount(session_id);
         let op_index: u64 = env.storage().persistent().get(&sopcnt_key).unwrap_or(0u64);
@@ -1822,6 +1838,7 @@ impl AnchorKitContract {
             timestamp,
             payload_hash,
             signature,
+            issuer_revoked: false,
         };
         let key = StorageKey::Attest(id);
         env.storage().persistent().set(&key, &attestation);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,10 @@ pub enum StorageKey {
     Sep10Key(Address),
     /// Whether an address is a registered attestor (persistent).
     Attestor(Address),
+    /// Revocation marker for an attestor — present when the attestor has been
+    /// revoked. Used by `get_attestation` to populate `issuer_revoked` without
+    /// rewriting every stored attestation (persistent).
+    AttestorRevoked(Address),
     /// HTTPS endpoint URL for an attestor (persistent).
     Endpoint(Address),
     /// Supported services record for an anchor (persistent).

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,6 +98,11 @@ pub struct Attestation {
     pub timestamp: u64,
     pub payload_hash: Bytes,
     pub signature: Bytes,
+    /// Set to `true` when the issuer attestor has been revoked after this
+    /// attestation was submitted. Historical attestations are preserved for
+    /// audit purposes; callers should treat `issuer_revoked = true` as a
+    /// signal that the issuer's authority has been withdrawn.
+    pub issuer_revoked: bool,
 }
 
 #[contracttype]


### PR DESCRIPTION
Historical attestations are preserved for audit purposes. A new StorageKey::AttestorRevoked(Address) persistent marker is written when an attestor is revoked (both revoke_attestor and revoke_attestor_with_session).

get_attestation and list_attestations now check this marker and set issuer_revoked=true on returned Attestation structs, so callers can distinguish active from revoked-issuer attestations without rewriting every stored attestation record.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using "Closes #123" or "Fixes #123" format -->
Closes #440 

## Changes Made
<!-- List the specific changes made in this PR -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No tests required (documentation, CI/CD, etc.)

## Test Coverage
<!-- If applicable, mention test coverage changes -->
- [ ] Test coverage maintained or improved
- [ ] New tests added for new functionality

## Documentation
<!-- Mark the appropriate option with an "x" -->
- [ ] Documentation updated (if applicable)
- [ ] No documentation changes needed
- [ ] Documentation will be added in a follow-up PR

## Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
- [ ] No breaking changes
- [ ] Breaking changes (please describe):

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
