### PR TITLE
fix request id entropy truncation

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -269,11 +269,7 @@ impl AnchorKitContract {
         }
 
         let hash = env.crypto().sha256(&input);
-        let hash_bytes = Bytes::from_array(&env, &hash.into());
-        let mut id = Bytes::new(&env);
-        for i in 0..16u32 {
-            id.push_back(hash_bytes.get(i).unwrap());
-        }
+        let id = Bytes::from_array(&env, &hash.into());
 
         RequestId { id, created_at: ts }
     }

--- a/src/request_id_tests.rs
+++ b/src/request_id_tests.rs
@@ -44,7 +44,7 @@ mod request_id_tests {
 
         let req_id = client.generate_request_id();
         assert_eq!(req_id.created_at, 1000);
-        assert_eq!(req_id.id.len(), 16);
+        assert_eq!(req_id.id.len(), 32);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR fixes request ID entropy truncation in `generate_request_id` by using the full 32-byte SHA-256 output instead of only the first 16 bytes.

### Problem

`generate_request_id` computed `sha256(timestamp || sequence)` but copied only 16 bytes into `RequestId.id`, reducing effective collision resistance and increasing birthday-collision risk under high throughput.

### Fix

- Updated `src/contract.rs`:
  - `generate_request_id` now stores all 32 bytes of the SHA-256 digest in `RequestId.id`.
- Updated `src/request_id_tests.rs`:
  - Adjusted request ID length assertion from `16` to `32`.

## Why This Change

Using the full digest preserves the intended security properties of SHA-256 for request ID generation and aligns with the issue requirement.

## Files Changed

- `src/contract.rs`
- `src/request_id_tests.rs`

## Validation

- Verified scoped diff only includes the request ID fix and corresponding test expectation update.
- Full test execution is currently blocked by pre-existing unrelated compile issues in other test modules.

closes #437 