### PR TITLE
fix: validate service values in configure_services (#445)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -478,6 +478,14 @@ impl AnchorKitContract {
         }
         let mut seen = Vec::new(&env);
         for s in services.iter() {
+            // Reject any value that is not one of the four known service constants.
+            if s != SERVICE_DEPOSITS
+                && s != SERVICE_WITHDRAWALS
+                && s != SERVICE_QUOTES
+                && s != SERVICE_KYC
+            {
+                panic_with_error!(&env, ErrorCode::InvalidServiceType);
+            }
             if seen.contains(s) {
                 panic_with_error!(&env, ErrorCode::InvalidServiceType);
             }


### PR DESCRIPTION
## Summary

Fixes #445

`configure_services` previously checked for duplicate service values but did not validate that each `u32` is one of the four known service constants. This allowed arbitrary values to be stored and silently pass `supports_service` checks.

## Changes

**`src/contract.rs` — `configure_services`**

Added a guard inside the iteration loop that rejects any value not equal to `SERVICE_DEPOSITS` (1), `SERVICE_WITHDRAWALS` (2), `SERVICE_QUOTES` (3), or `SERVICE_KYC` (4). The check runs before the duplicate check so the first invalid value panics immediately with `InvalidServiceType`.

```rust
// Reject any value that is not one of the four known service constants.
if s != SERVICE_DEPOSITS
    && s != SERVICE_WITHDRAWALS
    && s != SERVICE_QUOTES
    && s != SERVICE_KYC
{
    panic_with_error!(&env, ErrorCode::InvalidServiceType);
}
```

## Before
An anchor could call `configure_services` with `[1, 99, 255]` and the contract would store it without error. `supports_service(anchor, 99)` would then return `true`.

## After
Any value outside `{1, 2, 3, 4}` causes an immediate `InvalidServiceType` panic, keeping stored service lists strictly within the known set.
