### PR TITLE
fix: re-validate endpoint on read in get_endpoint (#446)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -455,9 +455,26 @@ impl AnchorKitContract {
         if !Self::is_attestor(env.clone(), attestor.clone()) {
             panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
         }
-        env.storage().persistent()
+        let endpoint: String = env
+            .storage()
+            .persistent()
             .get::<_, String>(&StorageKey::Endpoint(attestor))
-            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered));
+
+        // Re-validate on read: a storage entry written by an older contract version
+        // with looser validation rules must not be returned as a trusted URL.
+        let len = endpoint.len() as usize;
+        if len > 128 {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
+        let mut rust_buf = [0u8; 128];
+        endpoint.copy_into_slice(&mut rust_buf[..len]);
+        let endpoint_str = core::str::from_utf8(&rust_buf[..len]).unwrap_or("");
+        if crate::validate_anchor_domain(endpoint_str).is_err() {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
+
+        endpoint
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #446

`get_endpoint` previously returned the raw stored string without any validation. A storage entry written by an older contract version with looser rules could silently pass through as a trusted HTTPS URL.

## Fix

Re-validate the stored endpoint on read using the same logic as `set_endpoint`:
1. Reject if length exceeds 128 bytes (`InvalidEndpointFormat`).
2. Copy into a stack buffer, decode as UTF-8, and run `validate_anchor_domain`.
3. Panic with `InvalidEndpointFormat` if validation fails.

This is cheap (no storage write, no extra allocation beyond the existing stack buffer) and ensures callers always receive a value that passes current validation rules.

## Changes

**`src/contract.rs` — `get_endpoint`**

Added a re-validation block after the storage read, mirroring the validation already present in `set_endpoint`.

## Before
```rust
pub fn get_endpoint(env: Env, attestor: Address) -> String {
    if !Self::is_attestor(env.clone(), attestor.clone()) {
        panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
    }
    env.storage().persistent()
        .get::<_, String>(&StorageKey::Endpoint(attestor))
        .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered))
}
```

## After
```rust
pub fn get_endpoint(env: Env, attestor: Address) -> String {
    // ... fetch from storage ...
    // Re-validate on read: a storage entry written by an older contract version
    // with looser validation rules must not be returned as a trusted URL.
    if crate::validate_anchor_domain(endpoint_str).is_err() {
        panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
    }
    endpoint
}
```
