### PR TITLE
fix: validate expires_at, amount, network_passphrase, and supported_a…

### DIFF
--- a/src/anchor_info_discovery_tests.rs
+++ b/src/anchor_info_discovery_tests.rs
@@ -98,7 +98,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let toml = client.get_anchor_toml(&anchor);
         assert_eq!(toml.version, String::from_str(&env, "2.0.0"));
@@ -129,7 +129,7 @@ mod anchor_info_discovery_tests {
             web_auth_endpoint: String::from_str(&env, "https://auth.example.com"),
         };
 
-        client.fetch_anchor_info(&anchor, &toml_no_key, &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &toml_no_key, &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let toml = client.get_anchor_toml(&anchor);
         assert_eq!(toml.signing_key, None);
@@ -141,7 +141,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let toml = client.get_anchor_toml(&anchor);
         assert_eq!(toml.network_passphrase, String::from_str(&env, "Test SDF Network ; September 2015"));
@@ -164,7 +164,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 1000);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(1u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(1u64));
 
         set_ledger(&env, 1002);
         let result = client.try_get_anchor_toml(&anchor);
@@ -179,7 +179,7 @@ mod anchor_info_discovery_tests {
 
         // Override TTL to 7200s; cache should still be valid at timestamp 5000
         // (1000 + 7200 = 8200 > 5000)
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(7200u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(7200u64));
         set_ledger(&env, 5000);
         assert!(client.try_get_anchor_toml(&anchor).is_ok(), "cache should be valid within custom TTL");
 
@@ -190,7 +190,7 @@ mod anchor_info_discovery_tests {
         // None falls back to default 3600s TTL
         let anchor2 = Address::generate(&env);
         set_ledger(&env, 1000);
-        client.fetch_anchor_info(&anchor2, &sample_toml(&env), &None);
+        client.fetch_anchor_info(&anchor2, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &None);
         set_ledger(&env, 5000);
         assert!(client.try_get_anchor_toml(&anchor2).is_err(), "default 3600s TTL should expire at 5000");
     }
@@ -201,7 +201,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let assets = client.get_anchor_assets(&anchor);
         assert_eq!(assets.len(), 2);
@@ -215,7 +215,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(info.issuer, String::from_str(&env, "GABC123"));
@@ -228,7 +228,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let result = client.try_get_anchor_asset_info(&anchor, &String::from_str(&env, "BTC"));
         assert!(result.is_err());
@@ -255,7 +255,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (min, max) = client.get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(min, 1000);
@@ -279,7 +279,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (min, max) = client.get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(min, 500);
@@ -303,7 +303,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (fixed, percent) = client.get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(fixed, 100);
@@ -316,7 +316,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (fixed, percent) = client.get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(fixed, 50);
@@ -329,7 +329,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         assert!(client.anchor_supports_deposits(&anchor, &String::from_str(&env, "USDC")));
     }
@@ -340,7 +340,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         assert!(client.anchor_supports_withdrawals(&anchor, &String::from_str(&env, "USDC")));
     }
@@ -351,7 +351,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
         let _ = client.get_anchor_toml(&anchor);
 
         client.refresh_anchor_info(&anchor, &true);
@@ -367,7 +367,7 @@ mod anchor_info_discovery_tests {
         let (client, anchor) = setup(&env);
 
         // Cache with 3600s TTL
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
         
         // At 2000, still valid
         set_ledger(&env, 2000);
@@ -392,7 +392,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let usdc_info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
         let xlm_info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "XLM"));
@@ -407,7 +407,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "XLM"));
         assert_eq!(info.issuer, String::from_str(&env, "native"));
@@ -453,8 +453,8 @@ mod anchor_info_discovery_tests {
             web_auth_endpoint: String::from_str(&env, "https://auth2.example.com"),
         };
 
-        client.fetch_anchor_info(&anchor1, &sample_toml(&env), &Some(3600u64));
-        client.fetch_anchor_info(&anchor2, &toml2, &Some(3600u64));
+        client.fetch_anchor_info(&anchor1, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
+        client.fetch_anchor_info(&anchor2, &toml2, &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let info1 = client.get_anchor_asset_info(&anchor1, &String::from_str(&env, "USDC"));
         let info2 = client.get_anchor_asset_info(&anchor2, &String::from_str(&env, "USDC"));
@@ -471,7 +471,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (dep_min, dep_max) = client.get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
         let (wit_min, wit_max) = client.get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
@@ -490,7 +490,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let (dep_fixed, dep_pct) = client.get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
         let (wit_fixed, wit_pct) = client.get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
@@ -508,7 +508,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         // USDC and XLM both use 7 decimals on Stellar (the default)
         let usdc = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
@@ -549,7 +549,7 @@ mod anchor_info_discovery_tests {
             web_auth_endpoint: String::from_str(&env, "https://auth.example.com"),
         };
         let anchor2 = Address::generate(&env);
-        client.fetch_anchor_info(&anchor2, &toml_btc, &Some(3600u64));
+        client.fetch_anchor_info(&anchor2, &toml_btc, &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
         let btcln = client.get_anchor_asset_info(&anchor2, &String::from_str(&env, "BTCLN"));
         assert_eq!(btcln.decimals, 8);
     }
@@ -561,7 +561,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         // XLM asset has fee_fixed = 0 and fee_percent = 0 (see xlm_asset helper)
         let (dep_fixed, dep_pct) = client.get_anchor_deposit_fees(&anchor, &String::from_str(&env, "XLM"));
@@ -611,7 +611,7 @@ mod anchor_info_discovery_tests {
             web_auth_endpoint: String::from_str(&env, "https://auth.example.com"),
         };
 
-        client.fetch_anchor_info(&anchor, &toml, &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &toml, &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let result = client.get_anchor_currencies(&anchor);
         assert_eq!(result.len(), 2);
@@ -634,9 +634,90 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &Some(3600u64));
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &String::from_str(&env, "Test SDF Network ; September 2015"), &Some(3600u64));
 
         let result = client.get_anchor_currencies(&anchor);
         assert_eq!(result.len(), 0, "sample_toml has no fiat currencies");
+    }
+
+    // --- Issue #498: network_passphrase validation ---
+
+    #[test]
+    fn test_fetch_anchor_info_testnet_passphrase_accepted() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let result = client.try_fetch_anchor_info(
+            &anchor,
+            &sample_toml(&env),
+            &String::from_str(&env, "Test SDF Network ; September 2015"),
+            &Some(3600u64),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fetch_anchor_info_mainnet_passphrase_accepted() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let mut currencies = Vec::new(&env);
+        currencies.push_back(usdc_asset(&env));
+        let mut accounts = Vec::new(&env);
+        accounts.push_back(String::from_str(&env, "GANCHOR1"));
+
+        let mainnet_toml = StellarToml {
+            version: String::from_str(&env, "2.0.0"),
+            network_passphrase: String::from_str(&env, "Public Global Stellar Network ; September 2015"),
+            accounts,
+            signing_key: None,
+            currencies,
+            fiat_currencies: Vec::new(&env),
+            transfer_server: String::from_str(&env, "https://api.example.com"),
+            transfer_server_sep0024: String::from_str(&env, "https://api.example.com/sep24"),
+            kyc_server: String::from_str(&env, "https://kyc.example.com"),
+            web_auth_endpoint: String::from_str(&env, "https://auth.example.com"),
+        };
+
+        let result = client.try_fetch_anchor_info(
+            &anchor,
+            &mainnet_toml,
+            &String::from_str(&env, "Public Global Stellar Network ; September 2015"),
+            &Some(3600u64),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fetch_anchor_info_unknown_passphrase_rejected() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let result = client.try_fetch_anchor_info(
+            &anchor,
+            &sample_toml(&env),
+            &String::from_str(&env, "Some Unknown Network ; January 2024"),
+            &Some(3600u64),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fetch_anchor_info_mismatched_passphrase_rejected() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        // TOML has testnet passphrase but caller supplies mainnet — must be rejected
+        let result = client.try_fetch_anchor_info(
+            &anchor,
+            &sample_toml(&env),
+            &String::from_str(&env, "Public Global Stellar Network ; September 2015"),
+            &Some(3600u64),
+        );
+        assert!(result.is_err());
     }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1615,8 +1615,37 @@ impl AnchorKitContract {
     // Anchor Info Discovery
     // -----------------------------------------------------------------------
 
-    pub fn fetch_anchor_info(env: Env, anchor: Address, toml_data: StellarToml, ttl_override: Option<u64>) {
+    pub fn fetch_anchor_info(env: Env, anchor: Address, toml_data: StellarToml, network_passphrase: String, ttl_override: Option<u64>) {
         anchor.require_auth();
+
+        // Validate network_passphrase matches a known network before caching.
+        // Prevents caching a TOML from the wrong network, which would cause
+        // SEP-10 verification to succeed against the wrong signing key.
+        let np_len = network_passphrase.len() as usize;
+        if np_len > 256 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let mut np_buf = [0u8; 256];
+        network_passphrase.copy_into_slice(&mut np_buf[..np_len]);
+        let np_str = core::str::from_utf8(&np_buf[..np_len]).unwrap_or("");
+
+        const MAINNET: &str = "Public Global Stellar Network ; September 2015";
+        const TESTNET: &str = "Test SDF Network ; September 2015";
+        if np_str != MAINNET && np_str != TESTNET {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        // Validate that the TOML's own network_passphrase matches the supplied one.
+        let toml_np_len = toml_data.network_passphrase.len() as usize;
+        if toml_np_len > 256 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let mut toml_np_buf = [0u8; 256];
+        toml_data.network_passphrase.copy_into_slice(&mut toml_np_buf[..toml_np_len]);
+        let toml_np_str = core::str::from_utf8(&toml_np_buf[..toml_np_len]).unwrap_or("");
+        if toml_np_str != np_str {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
 
         // Reject non-HTTPS endpoints to prevent MITM exposure of anchor metadata.
         let ts_len = toml_data.transfer_server.len() as usize;

--- a/src/response_validator.rs
+++ b/src/response_validator.rs
@@ -43,12 +43,14 @@ pub struct AnchorInfoResponse {
 }
 
 /// Validates a raw deposit response map, returning a typed [`DepositResponse`]
-/// or [`Error::validation_error`] if any required field is missing or empty.
+/// or [`Error::validation_error`] if any required field is missing or empty,
+/// or if `expires_at` is not strictly in the future relative to `current_time`.
 pub fn validate_deposit_response(
     transaction_id: &str,
     status: &str,
     deposit_address: &str,
     expires_at: u64,
+    current_time: u64,
 ) -> Result<DepositResponse, Error> {
     if transaction_id.is_empty() {
         return Err(Error::validation_error("transaction_id is empty"));
@@ -58,6 +60,9 @@ pub fn validate_deposit_response(
     }
     if deposit_address.is_empty() {
         return Err(Error::validation_error("deposit_address is empty"));
+    }
+    if expires_at <= current_time {
+        return Err(Error::validation_error("deposit has already expired"));
     }
 
     Ok(DepositResponse {
@@ -90,7 +95,8 @@ pub fn validate_withdraw_response(
 }
 
 /// Validates a raw quote response, returning a typed [`QuoteResponse`]
-/// or [`Error::validation_error`] if any required field is missing or empty.
+/// or [`Error::validation_error`] if any required field is missing or empty,
+/// or if `amount` is zero.
 pub fn validate_quote_response(
     id: &str,
     status: &str,
@@ -106,6 +112,9 @@ pub fn validate_quote_response(
     }
     if asset.is_empty() {
         return Err(Error::validation_error("asset is empty"));
+    }
+    if amount == 0 {
+        return Err(Error::validation_error("amount must be greater than zero"));
     }
 
     Ok(QuoteResponse {
@@ -144,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_valid_deposit_response() {
-        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 9999);
+        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 9999, 1000);
         assert!(result.is_ok());
         let r = result.unwrap();
         assert_eq!(r.transaction_id, "dep_123");
@@ -155,29 +164,58 @@ mod tests {
 
     #[test]
     fn test_deposit_missing_transaction_id() {
-        let result = validate_deposit_response("", "pending", "GDEPOSIT...", 9999);
+        let result = validate_deposit_response("", "pending", "GDEPOSIT...", 9999, 1000);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, crate::errors::ErrorCode::ValidationError);
     }
 
     #[test]
     fn test_deposit_missing_status() {
-        let result = validate_deposit_response("dep_123", "", "GDEPOSIT...", 9999);
+        let result = validate_deposit_response("dep_123", "", "GDEPOSIT...", 9999, 1000);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, crate::errors::ErrorCode::ValidationError);
     }
 
     #[test]
     fn test_deposit_missing_deposit_address() {
-        let result = validate_deposit_response("dep_123", "pending", "", 9999);
+        let result = validate_deposit_response("dep_123", "pending", "", 9999, 1000);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, crate::errors::ErrorCode::ValidationError);
     }
 
     #[test]
-    fn test_deposit_zero_expires_at_is_valid() {
-        // expires_at = 0 is a valid u64; only string fields are required
-        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 0);
+    fn test_deposit_zero_expires_at_fails() {
+        // expires_at = 0 is always in the past — must be rejected
+        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 0, 1000);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::ValidationError);
+        assert!(err.context.as_deref().unwrap_or("").contains("expired"));
+    }
+
+    #[test]
+    fn test_deposit_past_expires_at_fails() {
+        // expires_at in the past relative to current_time
+        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 500, 1000);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::ValidationError);
+        assert!(err.context.as_deref().unwrap_or("").contains("expired"));
+    }
+
+    #[test]
+    fn test_deposit_expires_at_equal_to_current_time_fails() {
+        // expires_at == current_time is not strictly in the future
+        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 1000, 1000);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::ValidationError);
+        assert!(err.context.as_deref().unwrap_or("").contains("expired"));
+    }
+
+    #[test]
+    fn test_deposit_future_expires_at_passes() {
+        let result = validate_deposit_response("dep_123", "pending", "GDEPOSIT...", 2000, 1000);
         assert!(result.is_ok());
     }
 
@@ -243,9 +281,19 @@ mod tests {
     }
 
     #[test]
-    fn test_quote_zero_amount_is_valid() {
-        // amount = 0 is technically valid (e.g. free transactions)
+    fn test_quote_zero_amount_fails() {
+        // amount = 0 must be rejected to prevent division-by-zero downstream
         let result = validate_quote_response("quote_789", "quoted", 0, "USDC", 0);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::ValidationError);
+        assert!(err.context.as_deref().unwrap_or("").contains("amount must be greater than zero"));
+    }
+
+    #[test]
+    fn test_quote_zero_fee_with_nonzero_amount_passes() {
+        // fee = 0 is valid (free transaction); only amount must be > 0
+        let result = validate_quote_response("quote_789", "quoted", 100_0000000, "USDC", 0);
         assert!(result.is_ok());
     }
 
@@ -284,7 +332,7 @@ mod tests {
     #[test]
     fn test_validation_error_does_not_panic() {
         // Simulates SDK consumer handling the error gracefully
-        let result = validate_deposit_response("", "", "", 0);
+        let result = validate_deposit_response("", "", "", 0, 1000);
         match result {
             Err(e) if e.code == crate::errors::ErrorCode::ValidationError => { /* handled, no crash */ }
             _ => panic!("Expected ValidationError"),


### PR DESCRIPTION
Fixes four validation gaps in the response validator and anchor info discovery.

Closes #495
Closes #496
Closes #497
Closes #498

## Changes

**#497 — validate_deposit_response**
- Added \`current_time\` parameter
- Rejects \`expires_at <= current_time\` with context \`deposit has already expired\`

**#496 — validate_anchor_info_response**
- Already present in codebase; confirmed \`supported_assets is empty\` check is in place

**#495 — validate_quote_response**
- Rejects \`amount == 0\` with context \`amount must be greater than zero\`
- \`fee = 0\` remains valid (free transactions)

**#498 — fetch_anchor_info / cache_toml**
- Added \`network_passphrase\` parameter
- Validates passphrase is either mainnet (\`Public Global Stellar Network ; September 2015\`) or testnet (\`Test SDF Network ; September 2015\`)
- Validates TOML's own \`network_passphrase\` matches the supplied value
- Panics with \`ValidationError\` on mismatch

## Tests
- Updated all existing tests to match new signatures
- Added new tests covering rejection of past/zero \`expires_at\`, zero \`amount\`, unknown network passphrase, and mismatched passphrase" --base main
