### PR TITLE
fix(#436): restrict replay window to asymmetric [now - window, now]

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1776,8 +1776,7 @@ impl AnchorKitContract {
             .get(&key_replay_window(env))
             .unwrap_or(300u64);
         let lower = now.saturating_sub(window);
-        let upper = now.saturating_add(window);
-        if timestamp < lower || timestamp > upper {
+        if timestamp < lower || timestamp > now {
             panic_with_error!(env, ErrorCode::InvalidTimestamp);
         }
     }

--- a/src/replay_window_tests.rs
+++ b/src/replay_window_tests.rs
@@ -146,6 +146,33 @@ mod replay_window_tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Future timestamp rejection (issue #436)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn rejects_future_timestamp_within_window() {
+        let env = make_env();
+        set_ts(&env, 1_000_000);
+        let (client, admin, attestor, sk) = setup(&env);
+
+        client.initialize(&admin, &100_u64, &None);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // timestamp = now + 1 s → future, must be rejected even though it's within the old symmetric window
+        let ts: u64 = 1_000_000 + 1;
+        let hash = dummy_hash(&env, 6);
+        let sig = sign_payload(&env, &sk, &hash);
+        client.submit_attestation(
+            &attestor,
+            &Address::generate(&env),
+            &ts,
+            &hash,
+            &sig,
+        );
+    }
+
     #[test]
     fn custom_window_zero_only_accepts_exact_timestamp() {
         let env = make_env();


### PR DESCRIPTION
## Problem
The replay window check accepted timestamps in `[now - window, now + window]`, allowing attackers to pre-sign attestations with future timestamps and submit them later, bypassing replay protection.

## Solution
Changed `check_timestamp` to reject any timestamp strictly greater than the current ledger time. The window is now asymmetric: `[now - window, now]`.

## Changes
- **src/contract.rs**: Removed upper bound calculation; changed condition from `timestamp > upper` to `timestamp > now`
- **src/replay_window_tests.rs**: Added `rejects_future_timestamp_within_window()` test to verify future timestamps are rejected

## Security Impact
Closes the pre-sign attack vector. Attestations must now have timestamps in the past or present, preventing time-shifting exploits.

## Testing
- Existing replay window tests pass
- New test verifies `now + 1` is rejected

Closes #436