### PR TITLE
  This PR resolves four documentation and structural issues in TransactionStateTracker and RoutingOptions

### DIFF
--- a/docs/features/TRANSACTION_STATE_TRACKER.md
+++ b/docs/features/TRANSACTION_STATE_TRACKER.md
@@ -4,6 +4,11 @@
 
 The Transaction State Tracker is a comprehensive system for managing and tracking the lifecycle of transactions within the AnchorKit smart contract. It provides a robust mechanism to track transactions through four distinct states: Pending, In-Progress, Completed, and Failed.
 
+> **⚠️ Off-Chain Utility Only**
+> `TransactionStateTracker` is an **off-chain SDK utility** and is **not backed by on-chain Soroban storage**.
+> It operates entirely in memory and cannot be queried via contract methods. Use this tracker in your client SDK
+> to maintain local transaction state during its lifecycle without storing state on the blockchain.
+
 ## Features
 
 ### Core States

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1,3 +1,12 @@
+//! Transaction state tracking for off-chain SDK usage.
+//!
+//! This module provides [`TransactionStateTracker`], an **off-chain only** utility
+//! that tracks transaction state transitions in memory. It is **not backed by
+//! on-chain Soroban storage** and cannot be queried via contract methods.
+//!
+//! Use this tracker in your client SDK to maintain local state of transaction
+//! lifecycle without storing state on the blockchain.
+
 use soroban_sdk::{contracttype, Address, Env, String};
 
 /// Transaction states for the state tracker
@@ -56,7 +65,12 @@ pub struct TransactionStateRecord {
     pub history: soroban_sdk::Vec<StateTransition>,
 }
 
-/// Transaction state tracker
+/// Off-chain transaction state tracker.
+///
+/// This type operates entirely in memory and is **not backed by on-chain storage**.
+/// It is suitable for client-side SDK usage to track transaction state locally
+/// during its lifecycle, but state is not persisted to or queryable from the
+/// Soroban contract.
 #[derive(Clone)]
 #[allow(dead_code)]
 pub struct TransactionStateTracker {

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -77,8 +77,8 @@ pub struct TransactionStateTracker {
     cache: alloc::vec::Vec<TransactionStateRecord>,
     is_dev_mode: bool,
     /// Per-state counters indexed by TransactionState discriminant (1-based).
-    /// Index 0 is unused; indices 1-4 map to Pending/InProgress/Completed/Failed.
-    state_counts: [u64; 5],
+    /// Index 0 is unused; indices 1-5 map to Pending/InProgress/Completed/Failed/Unknown.
+    state_counts: [u64; 6],
 }
 
 #[allow(dead_code)]
@@ -88,7 +88,7 @@ impl TransactionStateTracker {
         TransactionStateTracker {
             cache: alloc::vec::Vec::new(),
             is_dev_mode,
-            state_counts: [0u64; 5],
+            state_counts: [0u64; 6],
         }
     }
 
@@ -293,7 +293,7 @@ impl TransactionStateTracker {
     pub fn clear_cache(&mut self, admin: &Address, _env: &Env) -> Result<(), String> {
         if self.is_dev_mode {
             self.cache = alloc::vec::Vec::new();
-            self.state_counts = [0u64; 5];
+            self.state_counts = [0u64; 6];
             Ok(())
         } else {
             admin.require_auth();
@@ -464,10 +464,25 @@ mod tests {
         let result = tracker.get_transaction_history(1, &env);
         assert!(result.is_ok());
         let history = result.unwrap();
-        
+
         assert_eq!(history.len(), 3);
         assert_eq!(history.get(0).unwrap().state, TransactionState::Pending);
         assert_eq!(history.get(1).unwrap().state, TransactionState::InProgress);
         assert_eq!(history.get(2).unwrap().state, TransactionState::Completed);
+    }
+
+    #[test]
+    fn test_unknown_state_counter() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+
+        // Verify that Unknown state (index 5) is accessible without panic
+        let count = tracker.get_transaction_count_by_state(TransactionState::Unknown);
+        assert_eq!(count, 0);
+
+        // Directly increment the Unknown state counter to simulate a transition
+        // This verifies the array is large enough
+        tracker.state_counts[TransactionState::Unknown as usize] = 1;
+        assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Unknown), 1);
     }
 }

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -75,7 +75,6 @@ pub struct TransactionStateRecord {
 #[allow(dead_code)]
 pub struct TransactionStateTracker {
     cache: alloc::vec::Vec<TransactionStateRecord>,
-    is_dev_mode: bool,
     /// Per-state counters indexed by TransactionState discriminant (1-based).
     /// Index 0 is unused; indices 1-5 map to Pending/InProgress/Completed/Failed/Unknown.
     state_counts: [u64; 6],
@@ -84,10 +83,9 @@ pub struct TransactionStateTracker {
 #[allow(dead_code)]
 impl TransactionStateTracker {
     /// Create a new transaction state tracker
-    pub fn new(is_dev_mode: bool) -> Self {
+    pub fn new() -> Self {
         TransactionStateTracker {
             cache: alloc::vec::Vec::new(),
-            is_dev_mode,
             state_counts: [0u64; 6],
         }
     }
@@ -118,10 +116,8 @@ impl TransactionStateTracker {
             },
         };
 
-        if self.is_dev_mode {
-            self.cache.push(record.clone());
-            self.state_counts[TransactionState::Pending as usize] += 1;
-        }
+        self.cache.push(record.clone());
+        self.state_counts[TransactionState::Pending as usize] += 1;
 
         Ok(record)
     }
@@ -169,54 +165,32 @@ impl TransactionStateTracker {
     ) -> Result<TransactionStateRecord, String> {
         let current_time = env.ledger().timestamp();
 
-        if self.is_dev_mode {
-            // Search and update in cache
-            for record in self.cache.iter_mut() {
-                if record.transaction_id == transaction_id {
-                    let old_state = record.state;
-                    record.state = new_state;
-                    record.last_updated = current_time;
-                    if new_state == TransactionState::Failed {
-                        record.error_message = error_message.clone();
-                    }
-                    record.error_message = error_message;
-                    record.history.push_back(StateTransition {
-                        state: new_state,
-                        timestamp: current_time,
-                    });
-                    // Update state counts
-                    if self.state_counts[old_state as usize] > 0 {
-                        self.state_counts[old_state as usize] -= 1;
-                    }
-                    self.state_counts[new_state as usize] += 1;
-                    return Ok(record.clone());
+        // Search and update in cache
+        for record in self.cache.iter_mut() {
+            if record.transaction_id == transaction_id {
+                let old_state = record.state;
+                record.state = new_state;
+                record.last_updated = current_time;
+                if new_state == TransactionState::Failed {
+                    record.error_message = error_message.clone();
                 }
+                record.error_message = error_message;
+                record.history.push_back(StateTransition {
+                    state: new_state,
+                    timestamp: current_time,
+                });
+                // Update state counts
+                if self.state_counts[old_state as usize] > 0 {
+                    self.state_counts[old_state as usize] -= 1;
+                }
+                self.state_counts[new_state as usize] += 1;
+                return Ok(record.clone());
             }
-            Err(String::from_str(
-                env,
-                "Transaction not found in cache",
-            ))
-        } else {
-            let dummy_address = Address::from_string(&String::from_str(env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
-            let _failure_reason = if new_state == TransactionState::Failed { error_message.clone() } else { None };
-            let record = TransactionStateRecord {
-                transaction_id,
-                state: new_state,
-                initiator: dummy_address,
-                timestamp: current_time,
-                last_updated: current_time,
-                error_message,
-                history: {
-                    let mut h = soroban_sdk::Vec::new(env);
-                    h.push_back(StateTransition {
-                        state: new_state,
-                        timestamp: current_time,
-                    });
-                    h
-                },
-            };
-            Ok(record)
         }
+        Err(String::from_str(
+            env,
+            "Transaction not found in cache",
+        ))
     }
 
     /// Get transaction state by ID
@@ -225,17 +199,12 @@ impl TransactionStateTracker {
         transaction_id: u64,
         _env: &Env,
     ) -> Result<Option<TransactionStateRecord>, String> {
-        if self.is_dev_mode {
-            for record in self.cache.iter() {
-                if record.transaction_id == transaction_id {
-                    return Ok(Some(record.clone()));
-                }
+        for record in self.cache.iter() {
+            if record.transaction_id == transaction_id {
+                return Ok(Some(record.clone()));
             }
-            Ok(None)
-        } else {
-            // In production, this would query the DB
-            Ok(None)
         }
+        Ok(None)
     }
 
     /// Get transaction history by ID
@@ -244,17 +213,12 @@ impl TransactionStateTracker {
         transaction_id: u64,
         _env: &Env,
     ) -> Result<soroban_sdk::Vec<StateTransition>, String> {
-        if self.is_dev_mode {
-            for record in self.cache.iter() {
-                if record.transaction_id == transaction_id {
-                    return Ok(record.history.clone());
-                }
+        for record in self.cache.iter() {
+            if record.transaction_id == transaction_id {
+                return Ok(record.history.clone());
             }
-            Err(String::from_str(_env, "Transaction not found"))
-        } else {
-            // In production, this would query the DB
-            Ok(soroban_sdk::Vec::new(_env))
         }
+        Err(String::from_str(_env, "Transaction not found"))
     }
 
 
@@ -263,43 +227,27 @@ impl TransactionStateTracker {
         &self,
         state: TransactionState,
     ) -> Result<alloc::vec::Vec<TransactionStateRecord>, String> {
-        if self.is_dev_mode {
-            let mut result = alloc::vec::Vec::new();
-            for record in self.cache.iter() {
-                if record.state == state {
-                    result.push(record.clone());
-                }
+        let mut result = alloc::vec::Vec::new();
+        for record in self.cache.iter() {
+            if record.state == state {
+                result.push(record.clone());
             }
-            Ok(result)
-        } else {
-            // In production, this would query the DB
-            Ok(alloc::vec::Vec::new())
         }
+        Ok(result)
     }
 
     /// Get all transactions
     pub fn get_all_transactions(&self) -> Result<alloc::vec::Vec<TransactionStateRecord>, String> {
-        if self.is_dev_mode {
-            Ok(self.cache.clone())
-        } else {
-            // In production, this would query the DB
-            Ok(alloc::vec::Vec::new())
-        }
+        Ok(self.cache.clone())
     }
 
     /// Clear all cached transactions.
-    /// In dev mode: always allowed.
-    /// In production mode: requires admin authorization.
+    /// Requires admin authorization.
     pub fn clear_cache(&mut self, admin: &Address, _env: &Env) -> Result<(), String> {
-        if self.is_dev_mode {
-            self.cache = alloc::vec::Vec::new();
-            self.state_counts = [0u64; 6];
-            Ok(())
-        } else {
-            admin.require_auth();
-            self.cache = alloc::vec::Vec::new();
-            Ok(())
-        }
+        admin.require_auth();
+        self.cache = alloc::vec::Vec::new();
+        self.state_counts = [0u64; 6];
+        Ok(())
     }
 
     /// Get cache size — O(1)
@@ -323,7 +271,7 @@ mod tests {
     #[test]
     fn test_create_transaction() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         let result = tracker.create_transaction(1, initiator.clone(), &env);
@@ -338,7 +286,7 @@ mod tests {
     #[test]
     fn test_start_transaction() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -352,7 +300,7 @@ mod tests {
     #[test]
     fn test_complete_transaction() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -367,7 +315,7 @@ mod tests {
     #[test]
     fn test_fail_transaction() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -383,7 +331,7 @@ mod tests {
     #[test]
     fn test_get_transaction_state() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -398,7 +346,7 @@ mod tests {
     #[test]
     fn test_get_transactions_by_state() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -414,7 +362,7 @@ mod tests {
     #[test]
     fn test_get_all_transactions() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -429,7 +377,7 @@ mod tests {
     #[test]
     fn test_cache_size() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -441,7 +389,7 @@ mod tests {
     #[test]
     fn test_clear_cache() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -454,7 +402,7 @@ mod tests {
     #[test]
     fn test_transaction_history_lifecycle() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
         let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
         tracker.create_transaction(1, initiator.clone(), &env).ok();
@@ -474,7 +422,7 @@ mod tests {
     #[test]
     fn test_unknown_state_counter() {
         let env = Env::default();
-        let mut tracker = TransactionStateTracker::new(true);
+        let mut tracker = TransactionStateTracker::new();
 
         // Verify that Unknown state (index 5) is accessible without panic
         let count = tracker.get_transaction_count_by_state(TransactionState::Unknown);
@@ -484,5 +432,20 @@ mod tests {
         // This verifies the array is large enough
         tracker.state_counts[TransactionState::Unknown as usize] = 1;
         assert_eq!(tracker.get_transaction_count_by_state(TransactionState::Unknown), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_clear_cache_requires_admin_auth() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new();
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let different_admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).ok();
+        assert_eq!(tracker.cache_size(), 1);
+
+        // This should panic because different_admin has not authorized this call
+        tracker.clear_cache(&different_admin, &env).ok();
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -152,8 +152,9 @@ pub struct RoutingRequest {
 /// # Other fields
 ///
 /// - `min_reputation` — anchors with a `reputation_score` strictly below this
-///   value are excluded before strategy selection. Set to `0` (the default) to
-///   include all active anchors regardless of reputation.
+///   value are excluded before strategy selection. When `min_reputation = 0`,
+///   reputation filtering is disabled and all anchors are included regardless
+///   of their reputation score.
 /// - `max_anchors` / `require_kyc` — reserved for future filtering; not yet
 ///   enforced by the current implementation.
 #[contracttype]


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  This PR resolves four documentation and structural issues in TransactionStateTracker and RoutingOptions:                                                                                      
                                                                                                                                                                                                
  - **#491**: Clarified `min_reputation = 0` behavior in RoutingOptions doc comment
  - **#492**: Documented TransactionStateTracker as off-chain only utility (not backed by on-chain storage)                                                                                     
  - **#493**: Fixed array out of bounds issue by increasing `state_counts` from `[u64; 5]` to `[u64; 6]` to accommodate Unknown state                                                           
  - **#494**: Removed `is_dev_mode` runtime flag and made `clear_cache` always require admin authorization                                                                                      
                                        
Closes #491 
Closes #492 
Closes #493 
Closes #494                                                                                                                                                         
  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  ### Issue #491 - RoutingOptions Documentation
  - Updated doc comment for `min_reputation` field to explicitly state: "When `min_reputation = 0`, reputation filtering is disabled and all anchors are included regardless of their reputation
   score."

  ### Issue #492 - TransactionStateTracker Off-Chain Documentation
  - Added module-level doc comment clarifying this is an off-chain SDK utility
  - Updated struct doc comment with prominent notice about in-memory operation and no on-chain storage backing
  - Added warning note to `docs/features/TRANSACTION_STATE_TRACKER.md` explaining off-chain nature

  ### Issue #493 - State Counts Array Fix
  - Changed `state_counts: [u64; 5]` to `state_counts: [u64; 6]` in struct definition (3 locations)
  - Updated comment: "Index 0 is unused; indices 1-5 map to Pending/InProgress/Completed/Failed/Unknown"
  - All array accesses use `TransactionState as usize` pattern (verified no hardcoded indices)
  - Added test `test_unknown_state_counter()` to verify Unknown state (index 5) works without panic

  ### Issue #494 - Remove is_dev_mode Field
  - Removed `is_dev_mode` field entirely from `TransactionStateTracker`
  - Simplified `new()` method signature (no longer takes `is_dev_mode` parameter)
  - Removed all runtime conditionals; tracker now always uses in-memory cache
  - Updated `clear_cache()` to always require admin authorization (removed dev mode bypass)
  - Updated all 11 test cases to use `new()` without arguments
  - Added `test_clear_cache_requires_admin_auth()` with `#[should_panic]` to verify authorization requirement

  ## Testing

  - Library compiles without errors
  - All existing tests updated and passing
  - New test added for Unknown state counter
  - New test added for admin auth requirement in clear_cache