### PR TITLE
fix: resolve contract issues #455 #456 #457 #458

### DIFF
--- a/src/attestation_pagination_tests.rs
+++ b/src/attestation_pagination_tests.rs
@@ -182,8 +182,7 @@ mod attestation_pagination_tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_attestation_id_overflow_panics() {
+    fn test_attestation_id_overflow_returns_limit_reached() {
         let env = make_env();
         setup_ledger(&env);
         let contract_id = env.register_contract(None, AnchorKitContract);
@@ -194,18 +193,19 @@ mod attestation_pagination_tests {
         let subject = Address::generate(&env);
         client.initialize(&admin, &100_u64, &None);
 
-        // Seed the counter to u64::MAX so the next increment overflows
+        // Seed the counter to u64::MAX - 1 so the next increment hits the limit
         env.as_contract(&contract_id, &|| {
             let ck = soroban_sdk::vec![&env, soroban_sdk::symbol_short!("COUNTER")];
-            env.storage().instance().set(&ck, &u64::MAX);
+            env.storage().instance().set(&ck, &(u64::MAX - 1));
         });
 
         let sk = SigningKey::generate(&mut OsRng);
         register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
 
-        // This should panic due to overflow guard
+        // Should return Err(AttestationLimitReached) instead of panicking
         let p = payload(&env, 1);
-        client.submit_attestation(&attestor, &subject, &1700000001, &p, &sign_payload(&env, &sk, &p));
+        let result = client.try_submit_attestation(&attestor, &subject, &1700000001, &p, &sign_payload(&env, &sk, &p));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -282,18 +282,41 @@ impl AnchorKitContract {
     // Attestor management
     // -----------------------------------------------------------------------
 
-    pub fn set_sep10_jwt_verifying_key(env: Env, issuer: Address, public_key: Bytes) {
+    pub fn upsert_sep10_verifying_key(env: Env, issuer: Address, public_key: Bytes) {
         Self::require_admin(&env);
         if public_key.len() != 32 {
             panic_with_error!(&env, ErrorCode::ValidationError);
         }
-        let mut keys: Vec<Bytes> = Vec::new(&env);
-        keys.push_back(public_key);
         let storage_key = StorageKey::Sep10Key(issuer.clone());
+        let mut keys: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&storage_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        // Replace in-place if the key already exists; otherwise append.
+        let mut found = false;
+        for i in 0..keys.len() {
+            if keys.get(i).unwrap() == public_key {
+                keys.set(i, public_key.clone());
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            if keys.len() >= sep10_jwt::MAX_VERIFYING_KEYS {
+                panic_with_error!(&env, ErrorCode::ValidationError);
+            }
+            keys.push_back(public_key);
+        }
         env.storage().persistent().set(&storage_key, &keys);
         env.storage()
             .persistent()
             .extend_ttl(&storage_key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Deprecated alias kept for backward compatibility. Use `upsert_sep10_verifying_key` instead.
+    pub fn set_sep10_jwt_verifying_key(env: Env, issuer: Address, public_key: Bytes) {
+        Self::upsert_sep10_verifying_key(env, issuer, public_key);
     }
 
     pub fn add_sep10_verifying_key(env: Env, issuer: Address, public_key: Bytes) {
@@ -707,6 +730,18 @@ impl AnchorKitContract {
     // -----------------------------------------------------------------------
 
     pub fn compute_payload_hash(env: Env, subject: Address, timestamp: u64, data: Bytes) -> BytesN<32> {
+        compute_payload_hash(&env, &subject, timestamp, &data)
+    }
+
+    /// Compute the canonical payload hash via the contract method.
+    ///
+    /// Off-chain callers should prefer this method over calling
+    /// `deterministic_hash::compute_payload_hash` directly. Going through the
+    /// Soroban host environment ensures that `Address` XDR serialisation uses
+    /// the same host-side encoding as on-chain attestation submission, avoiding
+    /// divergence that can occur when the module function is called outside the
+    /// host context.
+    pub fn compute_payload_hash_public(env: Env, subject: Address, timestamp: u64, data: Bytes) -> BytesN<32> {
         compute_payload_hash(&env, &subject, timestamp, &data)
     }
 
@@ -1786,7 +1821,10 @@ impl AnchorKitContract {
         let inst = env.storage().instance();
         let ck = key_counter(env);
         let id: u64 = inst.get(&ck).unwrap_or(0u64);
-        let next = id.checked_add(1).unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        let next = id.saturating_add(1);
+        if next == u64::MAX {
+            panic_with_error!(env, ErrorCode::AttestationLimitReached);
+        }
         inst.set(&ck, &next);
         inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         id

--- a/src/deterministic_hash.rs
+++ b/src/deterministic_hash.rs
@@ -4,6 +4,14 @@ use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
 ///
 /// Field ordering is fixed (canonical): subject bytes || timestamp (8-byte BE) || data bytes.
 /// This guarantees the same inputs always produce the same 32-byte hash.
+///
+/// # Off-chain callers
+///
+/// Prefer calling the contract method `compute_payload_hash_public` instead of this function
+/// directly. The contract method goes through the Soroban host environment, which ensures
+/// `Address` XDR serialisation uses the same host-side encoding as on-chain attestation
+/// submission. Calling this module function outside the host context may produce different
+/// XDR bytes for `Address` types, causing hash divergence that breaks attestation verification.
 pub fn compute_payload_hash(
     env: &Env,
     subject: &Address,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,7 @@ pub enum ErrorCode {
     UnauthorizedProposeAdmin = 52,
     NoPendingAdmin = 53,
     NotPendingAdmin = 54,
+    AttestationLimitReached = 55,
 }
 
 impl ErrorCode {
@@ -83,6 +84,7 @@ impl ErrorCode {
             ErrorCode::UnauthorizedProposeAdmin => "A pending admin proposal already exists",
             ErrorCode::NoPendingAdmin => "No pending admin transfer found",
             ErrorCode::NotPendingAdmin => "Caller is not the pending admin",
+            ErrorCode::AttestationLimitReached => "Attestation ID counter has reached u64::MAX",
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,3 +94,6 @@ mod replay_window_tests;
 
 #[cfg(test)]
 mod anchor_health_score_tests;
+
+#[cfg(test)]
+mod compute_payload_hash_tests;

--- a/src/metadata_cache_tests.rs
+++ b/src/metadata_cache_tests.rs
@@ -332,4 +332,32 @@ mod metadata_cache_tests {
         assert!(!list.contains(&anchor1));
         assert!(list.contains(&anchor2));
     }
+
+    // Issue #458: cache_metadata must append anchor to CANCHORS persistent list
+    #[test]
+    fn test_cache_metadata_appends_to_canchors() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor = Address::generate(&env);
+        client.initialize(&admin, &100_u64, &None);
+
+        // Before caching, list is empty
+        assert_eq!(client.list_cached_anchors().len(), 0);
+
+        let meta = sample_metadata(&env, &anchor);
+        client.cache_metadata(&anchor, &meta, &3600u64);
+
+        // After caching, anchor appears in list
+        let list = client.list_cached_anchors();
+        assert_eq!(list.len(), 1);
+        assert!(list.contains(&anchor));
+
+        // Calling cache_metadata again with same anchor must not duplicate it
+        client.cache_metadata(&anchor, &sample_metadata(&env, &anchor), &7200u64);
+        assert_eq!(client.list_cached_anchors().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes four contract bugs in a single PR.

Closes #455
Closes #456
Closes #457
Closes #458

---

### #455 — `set_sep10_jwt_verifying_key` overwrites all keys

Renamed to `upsert_sep10_verifying_key`. New implementation iterates the stored key list and replaces the matching key in-place; if not found, appends it (respecting `MAX_VERIFYING_KEYS`). The old name is kept as a deprecated alias delegating to the new function so all existing call sites continue to work.

### #456 — `next_attestation_id` can overflow and panic

- Added `AttestationLimitReached = 55` to `ErrorCode`.
- Replaced `checked_add(...).unwrap_or_else(panic)` with `saturating_add(1)` + explicit check `if next == u64::MAX { panic_with_error!(AttestationLimitReached) }`.
- Replaced `#[should_panic] test_attestation_id_overflow_panics` with `test_attestation_id_overflow_returns_limit_reached` that asserts `try_submit_attestation` returns `Err`.

### #457 — `compute_payload_hash` exposed via two paths with potential divergence

- Added `compute_payload_hash_public` contract method so off-chain callers go through the Soroban host environment (same XDR serialisation as on-chain).
- Added doc comment on `deterministic_hash::compute_payload_hash` warning about XDR divergence and directing callers to the contract method.
- Wired up `compute_payload_hash_tests` module in `lib.rs` so the existing integration tests are compiled and run.

### #458 — `cache_metadata` does not add anchor to CANCHORS list

The CANCHORS append logic was already present. Added focused test `test_cache_metadata_appends_to_canchors` that calls `cache_metadata` and asserts `list_cached_anchors` returns the anchor, and that a second call with the same anchor does not duplicate it.

---

### Files changed
- `src/contract.rs` — #455 upsert logic, #456 overflow fix, #457 new method
- `src/errors.rs` — #456 new error variant
- `src/deterministic_hash.rs` — #457 doc comment
- `src/lib.rs` — #457 test module wiring
- `src/attestation_pagination_tests.rs` — #456 updated test
- `src/metadata_cache_tests.rs` — #458 new test