### PR TITLE
Fix SEP-10 JWT validation and domain validator issues (#483-#486)                                                                                                      

### DIFF
--- a/src/domain_validator.rs
+++ b/src/domain_validator.rs
@@ -69,11 +69,44 @@ pub fn validate_anchor_domain(domain: &str) -> Result<(), AnchorKitError> {
         Some(h) if !h.is_empty() => h,
         _ => return Err(AnchorKitError::invalid_endpoint_format()),
     };
-    
+
     // Remove query parameters and fragments from host
-    let host = host_with_query
+    let host_with_port = host_with_query
         .split('?').next().unwrap_or(host_with_query)
         .split('#').next().unwrap_or(host_with_query);
+
+    // Parse host and port separately — extract just the host for validation
+    let host = if let Some(colon_pos) = host_with_port.rfind(':') {
+        // Validate port number before extracting just the host
+        let port_str = &host_with_port[colon_pos + 1..];
+        if port_str.is_empty() {
+            return Err(AnchorKitError::invalid_endpoint_format());
+        }
+
+        // Check if port is numeric
+        for c in port_str.chars() {
+            if !c.is_ascii_digit() {
+                return Err(AnchorKitError::invalid_endpoint_format());
+            }
+        }
+
+        // Validate port range (1-65535); reject port 80 since this validator
+        // is HTTPS-only and port 80 is the HTTP default — not a valid HTTPS port.
+        if let Ok(port) = port_str.parse::<u32>() {
+            if port == 0 || port > 65535 {
+                return Err(AnchorKitError::invalid_endpoint_format());
+            }
+            if port == 80 {
+                return Err(AnchorKitError::invalid_endpoint_format());
+            }
+        } else {
+            return Err(AnchorKitError::invalid_endpoint_format());
+        }
+
+        &host_with_port[..colon_pos]
+    } else {
+        host_with_port
+    };
 
     // Validate host structure
     validate_host(host)?;
@@ -106,38 +139,9 @@ fn validate_host(host: &str) -> Result<(), AnchorKitError> {
         return Err(AnchorKitError::invalid_endpoint_format());
     }
 
-    // Check for port specification (optional)
-    let domain_without_port = if let Some(colon_pos) = host.rfind(':') {
-        // Validate port number
-        let port_str = &host[colon_pos + 1..];
-        if port_str.is_empty() {
-            return Err(AnchorKitError::invalid_endpoint_format());
-        }
-        
-        // Check if port is numeric
-        for c in port_str.chars() {
-            if !c.is_ascii_digit() {
-                return Err(AnchorKitError::invalid_endpoint_format());
-            }
-        }
-        
-        // Validate port range (1-65535); reject port 80 since this validator
-        // is HTTPS-only and port 80 is the HTTP default — not a valid HTTPS port.
-        if let Ok(port) = port_str.parse::<u32>() {
-            if port == 0 || port > 65535 {
-                return Err(AnchorKitError::invalid_endpoint_format());
-            }
-            if port == 80 {
-                return Err(AnchorKitError::invalid_endpoint_format());
-            }
-        } else {
-            return Err(AnchorKitError::invalid_endpoint_format());
-        }
-        
-        &host[..colon_pos]
-    } else {
-        host
-    };
+    // Port validation and separation is done in validate_anchor_domain,
+    // so host should not contain a port here.
+    let domain_without_port = host;
 
     // Check for valid domain structure
     if domain_without_port.is_empty() {

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -84,6 +84,8 @@ fn parse_json_exp(payload: &[u8]) -> Result<u64, ()> {
     while i < payload.len() && payload[i].is_ascii_digit() {
         any = true;
         let d = (payload[i] - b'0') as u64;
+        // An exp value that overflows u64 is treated as a malformed token
+        // and causes verify_sep10_jwt to return Err(()) — this is intentional.
         n = n
             .checked_mul(10)
             .and_then(|x| x.checked_add(d))
@@ -388,6 +390,13 @@ mod tests {
 
         // Length 5 after padding removal: 5 % 4 == 1 — invalid
         assert!(base64url_decode(b"ABCDE").is_err());
+    }
+
+    #[test]
+    fn parse_json_exp_overflow() {
+        // exp value exceeding u64::MAX is treated as malformed
+        let payload = b"{\"exp\":99999999999999999999}";
+        assert!(parse_json_exp(payload).is_err());
     }
 
     #[test]

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -158,6 +158,35 @@ fn parse_json_scp(payload: &[u8]) -> Result<Vec<u8>, ()> {
     Err(())
 }
 
+/// Parse first `"alg":"..."` string value from the JWT header.
+fn parse_json_alg(header: &[u8]) -> Result<Vec<u8>, ()> {
+    let key = b"\"alg\":";
+    let pos = find_bytes(header, key).ok_or(())?;
+    let mut i = pos + key.len();
+    while i < header.len() && header[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= header.len() || header[i] != b'"' {
+        return Err(());
+    }
+    i += 1;
+    let start = i;
+    while i < header.len() {
+        if header[i] == b'\\' {
+            if i + 1 >= header.len() {
+                return Err(());
+            }
+            i += 2;
+            continue;
+        }
+        if header[i] == b'"' {
+            return Ok(header[start..i].to_vec());
+        }
+        i += 1;
+    }
+    Err(())
+}
+
 /// Returns the canonical scope name for a service code (matches SERVICE_* constants in contract.rs).
 pub fn service_scope_name(service_code: u32) -> Option<&'static [u8]> {
     match service_code {
@@ -279,7 +308,8 @@ pub fn verify_sep10_jwt(
     let sig_b64 = &buf[d1 + 1..n_usize];
 
     let header_dec = base64url_decode(header_b64).map_err(|_| ())?;
-    if !contains_subslice(&header_dec, b"EdDSA") {
+    let alg = parse_json_alg(&header_dec)?;
+    if alg != b"EdDSA" {
         return Err(());
     }
 
@@ -509,6 +539,30 @@ mod tests {
         format!("{}.{}", signing_input, sig_b64)
     }
 
+    fn build_jwt_with_custom_alg(signing_key: &SigningKey, sub: &str, exp: u64, alg: &str) -> std::string::String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = format!(r#"{{"alg":"{}","typ":"JWT"}}"#, alg);
+        let payload = format!(r#"{{"sub":"{}","exp":{}}}"#, sub, exp);
+        let header_b64 = URL_SAFE_NO_PAD.encode(header);
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{}.{}", header_b64, payload_b64);
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{}.{}", signing_input, sig_b64)
+    }
+
+    fn build_jwt_without_alg(signing_key: &SigningKey, sub: &str, exp: u64) -> std::string::String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = r#"{"typ":"JWT"}"#;
+        let payload = format!(r#"{{"sub":"{}","exp":{}}}"#, sub, exp);
+        let header_b64 = URL_SAFE_NO_PAD.encode(header);
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{}.{}", header_b64, payload_b64);
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{}.{}", signing_input, sig_b64)
+    }
+
     #[test]
     fn check_token_scope_matches() {
         let env = Env::default();
@@ -560,5 +614,34 @@ mod tests {
         assert!(verify_sep10_jwt(&env, &token, &keys, None, 60).is_ok());
         // With skew exactly equal to lag (30 s): exp + 30 = 1_030, not strictly greater — rejected.
         assert!(verify_sep10_jwt(&env, &token, &keys, None, 30).is_err());
+    }
+
+    #[test]
+    fn verify_validates_alg_header() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
+        let mut keys = soroban_sdk::Vec::new(&env);
+        keys.push_back(pk);
+
+        let attestor = Address::generate(&env);
+        let sub = attestor.to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // EdDSA token is accepted
+        let jwt = build_jwt(&signing_key, sub_str.as_str(), 2_000);
+        let token = String::from_str(&env, jwt.as_str());
+        assert!(verify_sep10_jwt(&env, &token, &keys, Some(&sub), 0).is_ok());
+
+        // HS256 token is rejected
+        let jwt_hs256 = build_jwt_with_custom_alg(&signing_key, sub_str.as_str(), 2_000, "HS256");
+        let token_hs256 = String::from_str(&env, jwt_hs256.as_str());
+        assert!(verify_sep10_jwt(&env, &token_hs256, &keys, Some(&sub), 0).is_err());
+
+        // Token with no alg field is rejected
+        let jwt_no_alg = build_jwt_without_alg(&signing_key, sub_str.as_str(), 2_000);
+        let token_no_alg = String::from_str(&env, jwt_no_alg.as_str());
+        assert!(verify_sep10_jwt(&env, &token_no_alg, &keys, Some(&sub), 0).is_err());
     }
 }

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -37,6 +37,12 @@ pub fn base64url_decode(input: &[u8]) -> Result<Vec<u8>, ()> {
         }
         &input[..end]
     };
+
+    // Invalid base64 if length mod 4 equals 1 after padding removal.
+    if input.len() % 4 == 1 {
+        return Err(());
+    }
+
     let mut out: Vec<u8> = Vec::new();
     let mut buffer: u32 = 0;
     let mut bits: u32 = 0;
@@ -371,6 +377,17 @@ mod tests {
 
         // Invalid character should still error
         assert!(base64url_decode(b"SGVs!G8").is_err());
+    }
+
+    #[test]
+    fn base64url_rejects_invalid_padding_length() {
+        // Length 1 after padding removal: 1 % 4 == 1 — invalid
+        assert!(base64url_decode(b"A").is_err());
+        assert!(base64url_decode(b"A=").is_err());
+        assert!(base64url_decode(b"A==").is_err());
+
+        // Length 5 after padding removal: 5 % 4 == 1 — invalid
+        assert!(base64url_decode(b"ABCDE").is_err());
     }
 
     #[test]


### PR DESCRIPTION
  ## Summary                                                                                                                                                               
                                                                                                                                                                           
  Fixed four critical validation issues in SEP-10 JWT verification and domain validation:                                                                                  
                                                                                                                                                                           
  - **#483**: Base64url decoder now rejects inputs with invalid padding length (where `len() % 4 == 1` after padding removal)                                              
  - **#484**: Documented exp overflow behavior with comment and added overflow test for values exceeding u64::MAX                                                          
  - **#485**: Implemented proper alg header field validation to ensure only "EdDSA" tokens are accepted                                                                    
  - **#486**: Refactored domain validator to parse host and port separately before dot-in-domain check      
Closes #483
Closes #484 
Closes #485 
Closes #486                                                                
                                                                                                                                                                           
  ## Changes                                                                                                                                                               
                                                                                                                                                                           
  ### sep10_jwt.rs                                                                                                                                                         
  - Added padding length validation in `base64url_decode`                                                                                                                  
  - Added overflow documentation and test in `parse_json_exp`                                                                                                              
  - Implemented `parse_json_alg` function for proper alg header extraction                                                                                                 
  - Updated `verify_sep10_jwt` to validate alg field strictly                                                                                                              
  - Added test cases for all alg validation scenarios                                                                                                                      
                                                                                                                                                                           
  ### domain_validator.rs                                                                                                                                                  
  - Moved port parsing and validation to `validate_anchor_domain`                                                                                                        
  - Apply dot-in-domain check only to host component, not host:port
  - Simplified `validate_host` by removing duplicated port logic                                                                                                           
   
  ## Test Coverage                                                                                                                                                         
  - ✅ base64url padding validation tests                                                                                                                                
  - ✅ exp overflow detection
  - ✅ alg header: EdDSA accepted, HS256/missing rejected
  - ✅ Port handling with domains                                                                                                                                          
  - ✅ Existing validation tests passing
  - ✅ Library builds without errors                                                                                                                                       
                                        