### PR TITLE
fix: add MissingSigningKey error code for SEP-10 verification without a registered signing key

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -339,7 +339,10 @@ impl AnchorKitContract {
             .storage()
             .persistent()
             .get(&StorageKey::Sep10Key(issuer.clone()))
-            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::InvalidSep10Token));
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::MissingSigningKey));
+        if keys.is_empty() {
+            panic_with_error!(&env, ErrorCode::MissingSigningKey);
+        }
         if sep10_jwt::verify_sep10_jwt(&env, &token, &keys, None, 0).is_err() {
             panic_with_error!(&env, ErrorCode::InvalidSep10Token);
         }
@@ -355,7 +358,10 @@ impl AnchorKitContract {
             .storage()
             .persistent()
             .get(&StorageKey::Sep10Key(issuer.clone()))
-            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::InvalidSep10Token));
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::MissingSigningKey));
+        if keys.is_empty() {
+            panic_with_error!(&env, ErrorCode::MissingSigningKey);
+        }
         if sep10_jwt::verify_sep10_jwt(&env, &token, &keys, None, 0).is_err() {
             panic_with_error!(&env, ErrorCode::InvalidSep10Token);
         }
@@ -374,7 +380,10 @@ impl AnchorKitContract {
             .storage()
             .persistent()
             .get(&StorageKey::Sep10Key(issuer.clone()))
-            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::InvalidSep10Token));
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::MissingSigningKey));
+        if keys.is_empty() {
+            panic_with_error!(env, ErrorCode::MissingSigningKey);
+        }
         let expected = attestor.to_string();
         if sep10_jwt::verify_sep10_jwt(env, token, &keys, Some(&expected), 0).is_err() {
             panic_with_error!(env, ErrorCode::InvalidSep10Token);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -98,6 +98,7 @@ pub enum ErrorCode {
     NotPendingAdmin = 54,
     SessionNotFound = 55,
     SessionExpired = 56,
+    MissingSigningKey = 57,
 }
 
 impl ErrorCode {
@@ -132,6 +133,7 @@ impl ErrorCode {
             ErrorCode::NotPendingAdmin => "Caller is not the pending admin",
             ErrorCode::SessionNotFound => "Session not found",
             ErrorCode::SessionExpired => "Session has expired",
+            ErrorCode::MissingSigningKey => "Anchor TOML does not publish a signing key",
         }
     }
 
@@ -220,6 +222,7 @@ impl AnchorKitError {
     pub fn storage_corrupted() -> Self { Self::from_code(ErrorCode::StorageCorrupted) }
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
+    pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
 
     pub fn validation_error(context: &str) -> Self {
         Self::with_context(ErrorCode::ValidationError, ErrorCode::ValidationError.default_message(), context)
@@ -268,6 +271,7 @@ impl AnchorKitError {
     pub fn storage_corrupted() -> Self { Self::from_code(ErrorCode::StorageCorrupted) }
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
+    pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
     pub fn validation_error(_context: &str) -> Self { Self::from_code(ErrorCode::ValidationError) }
 }
 
@@ -379,6 +383,7 @@ let codes = [
             ErrorCode::CacheNotFound,
             ErrorCode::SessionNotFound,
             ErrorCode::SessionExpired,
+            ErrorCode::MissingSigningKey,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());


### PR DESCRIPTION
Problem
  
  When an anchor's cached StellarToml has no signing_key (i.e. signing_key: None), calling
  verify_sep10_token would panic with InvalidSep10Token — giving no indication that the real
  cause was a missing signing key, not a bad token.
  
  Changes
  
  - src/errors.rs — Added ErrorCode::MissingSigningKey = 57 with message "Anchor TOML does not
  publish a signing key", plus missing_signing_key() constructor in both std and no-std impls.
  - src/contract.rs — Updated verify_sep10_token, verify_sep10_token_for_service, and
  verify_sep10_token_matches_attestor to panic with MissingSigningKey when no verifying key is
  registered for the issuer, or when the registered key list is empty.
  
  Result
  
  Callers now get a distinct, actionable error code (57) that clearly identifies the root cause,
  separate from a genuinely invalid/expired token (18).

close #505 