### PR TITLE
fix: add SEP-1/SEP-6 fields to FiatCurrency

### DIFF
--- a/src/anchor_info_discovery_tests.rs
+++ b/src/anchor_info_discovery_tests.rs
@@ -585,12 +585,18 @@ mod anchor_info_discovery_tests {
             name: String::from_str(&env, "US Dollar"),
             deposit_enabled: true,
             withdrawal_enabled: true,
+            country_code: Some(String::from_str(&env, "USA")),
+            desc: None,
+            display_decimals: Some(2),
         });
         fiat.push_back(FiatCurrency {
             code: String::from_str(&env, "EUR"),
             name: String::from_str(&env, "Euro"),
             deposit_enabled: true,
             withdrawal_enabled: false,
+            country_code: None,
+            desc: None,
+            display_decimals: None,
         });
 
         let mut currencies = Vec::new(&env);

--- a/src/types.rs
+++ b/src/types.rs
@@ -236,6 +236,12 @@ pub struct FiatCurrency {
     pub name: String,
     pub deposit_enabled: bool,
     pub withdrawal_enabled: bool,
+    /// ISO 3166-1 alpha-3 country code (e.g. "USA", "GBR"). From stellar.toml / SEP-6.
+    pub country_code: Option<String>,
+    /// Human-readable description of the currency.
+    pub desc: Option<String>,
+    /// Preferred number of decimal places to display (0–7).
+    pub display_decimals: Option<u32>,
 }
 
 #[contracttype]


### PR DESCRIPTION
Add SEP-1/SEP-6 fields to FiatCurrency
  
  FiatCurrency previously only stored code, name, deposit_enabled, and withdrawal_enabled, making
  it impossible to fully represent fiat currency entries from a stellar.toml file.
  
  Changes
  
  - src/types.rs: Added three optional fields to FiatCurrency:
    - country_code: Option<String> — ISO 3166-1 alpha-3 country code (e.g. "USA", "GBR"), used by
  SEP-6 deposit/withdraw endpoints to determine required KYC information
    - desc: Option<String> — human-readable description of the currency, as defined in SEP-1
  [[CURRENCIES]]
    - display_decimals: Option<u32> — preferred number of decimal places for display (0–7),
  sourced from the SEP-1 display_decimals field
  
  - src/anchor_info_discovery_tests.rs: Updated existing FiatCurrency constructors to include the
  new fields
  
  All fields are Option to maintain full backward compatibility with existing callers.
  
  References
  
  - SEP-1 — Stellar Info File, Currency Documentation
  (https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md)
  - SEP-6 — Deposit and Withdrawal API
  (https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md)

closes #506 