### PR TITLE
fix(metadata_cache): return Result from get_cache_age_seconds

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1178,12 +1178,14 @@ impl AnchorKitContract {
     }
 
     /// Issue #260: returns seconds elapsed since the metadata cache entry was written,
-    /// or `None` if no cache entry exists for the anchor.
-    pub fn get_cache_age_seconds(env: Env, anchor: Address) -> Option<u64> {
+    /// or `Err(CacheNotFound)` if no cache entry exists for the anchor.
+    /// `Ok(0)` means the entry was just cached at the current ledger timestamp.
+    pub fn get_cache_age_seconds(env: Env, anchor: Address) -> Result<u64, ErrorCode> {
         let key = StorageKey::MetadataCache(anchor);
-        let entry: MetadataCache = env.storage().temporary().get(&key)?;
+        let entry: MetadataCache = env.storage().temporary().get(&key)
+            .ok_or(ErrorCode::CacheNotFound)?;
         let now = env.ledger().timestamp();
-        Some(now.saturating_sub(entry.cached_at))
+        Ok(now.saturating_sub(entry.cached_at))
     }
 
     // #272: return the cached data so callers avoid a second storage read.

--- a/src/metadata_cache_tests.rs
+++ b/src/metadata_cache_tests.rs
@@ -230,8 +230,7 @@ mod metadata_cache_tests {
         // The cache entry should still have cached_at == 0 (original write)
         // We verify by checking the age is >= 100 seconds
         let age = client.get_cache_age_seconds(&anchor);
-        assert!(age.is_some());
-        assert!(age.unwrap() >= 100);
+        assert!(age >= 100);
     }
 
     // Issue #260: get_cache_age_seconds returns None when no entry, Some(age) when cached
@@ -246,8 +245,8 @@ mod metadata_cache_tests {
         let anchor = Address::generate(&env);
         client.initialize(&admin, &100_u64, &None);
 
-        // No entry yet
-        assert!(client.get_cache_age_seconds(&anchor).is_none());
+        // No entry yet — must return Err(CacheNotFound), not Ok(0)
+        assert!(client.try_get_cache_age_seconds(&anchor).is_err());
 
         let meta = sample_metadata(&env, &anchor);
         client.cache_metadata(&anchor, &meta, &3600u64);
@@ -255,7 +254,7 @@ mod metadata_cache_tests {
         // Advance 50 seconds
         set_ledger(&env, 1050);
         let age = client.get_cache_age_seconds(&anchor);
-        assert_eq!(age, Some(50));
+        assert_eq!(age, 50);
     }
 
     // Issue #258: invalidate_all_caches removes all entries and emits event


### PR DESCRIPTION
closes #503 

Callers could not distinguish a missing cache entry (None) from a brand-new entry cached at the exact current ledger timestamp (Some(0)).

Change the return type from Option<u64> to Result<u64, ErrorCode>:
- Ok(age)              — entry exists, age in seconds
- Err(CacheNotFound)   — no entry for this anchor

Update affected tests accordingly

Changes made:

- src/contract.rs — get_cache_age_seconds return type changed from Option<u64> to Result<u64, ErrorCode>. Missing entry now returns Err(ErrorCode::CacheNotFound) instead of None, making Ok(0) (just cached) 
unambiguous.
- src/metadata_cache_tests.rs — Updated two tests to match the new return type: is_none() → try_get_cache_age_seconds(...).is_err(), Some(50) → 50, and removed the now-unnecessary .is_some() / .unwrap() pair.