### PR TITLE
fix(metadata_cache): use persistent storage for ttl_seconds=0 entries

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1132,9 +1132,16 @@ impl AnchorKitContract {
 
     pub fn cache_metadata(env: Env, anchor: Address, metadata: AnchorMetadata, ttl_seconds: u64) {
         Self::require_admin(&env);
-        // Issue #259: skip write if metadata is unchanged
+        // Issue #259: skip write if metadata is unchanged.
+        // ttl_seconds=0 entries live in persistent storage (never network-evicted);
+        // all other entries live in temporary storage.
         let key = StorageKey::MetadataCache(anchor.clone());
-        if let Some(existing) = env.storage().temporary().get::<_, MetadataCache>(&key) {
+        let existing: Option<MetadataCache> = if ttl_seconds == 0 {
+            env.storage().persistent().get(&key)
+        } else {
+            env.storage().temporary().get(&key)
+        };
+        if let Some(existing) = existing {
             let m = &existing.metadata;
             if m.anchor == metadata.anchor
                 && m.reputation_score == metadata.reputation_score
@@ -1149,9 +1156,17 @@ impl AnchorKitContract {
         }
         let now = env.ledger().timestamp();
         let entry = MetadataCache { metadata, cached_at: now, ttl_seconds };
-        let ledger_ttl = if ttl_seconds as u32 > MIN_TEMP_TTL { ttl_seconds as u32 } else { MIN_TEMP_TTL };
-        env.storage().temporary().set(&key, &entry);
-        env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
+        if ttl_seconds == 0 {
+            // Persistent storage is not subject to network-level eviction within
+            // its TTL window, so ttl_seconds=0 ("never expire at app level") is
+            // backed by storage that won't disappear under the contract's feet.
+            env.storage().persistent().set(&key, &entry);
+            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        } else {
+            let ledger_ttl = if ttl_seconds as u32 > MIN_TEMP_TTL { ttl_seconds as u32 } else { MIN_TEMP_TTL };
+            env.storage().temporary().set(&key, &entry);
+            env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
+        }
 
         // Issue #276: maintain CACHED_ANCHORS set
         let list_key = soroban_sdk::vec![&env, symbol_short!("CANCHORS")];
@@ -1167,10 +1182,12 @@ impl AnchorKitContract {
 
     pub fn get_cached_metadata(env: Env, anchor: Address) -> AnchorMetadata {
         let key = StorageKey::MetadataCache(anchor);
-        let entry: MetadataCache = env.storage().temporary().get(&key)
+        // ttl_seconds=0 entries are stored persistently; all others are temporary.
+        let entry: MetadataCache = env.storage().persistent().get(&key)
+            .or_else(|| env.storage().temporary().get(&key))
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::CacheNotFound));
         let now = env.ledger().timestamp();
-        // ttl_seconds = 0 means "never expire" — skip the expiry check to prevent refresh loops
+        // ttl_seconds = 0 means "never expire at app level" — skip the expiry check
         if entry.ttl_seconds != 0 && entry.cached_at + entry.ttl_seconds <= now {
             panic_with_error!(&env, ErrorCode::CacheExpired);
         }
@@ -1181,7 +1198,8 @@ impl AnchorKitContract {
     /// or `None` if no cache entry exists for the anchor.
     pub fn get_cache_age_seconds(env: Env, anchor: Address) -> Option<u64> {
         let key = StorageKey::MetadataCache(anchor);
-        let entry: MetadataCache = env.storage().temporary().get(&key)?;
+        let entry: MetadataCache = env.storage().persistent().get(&key)
+            .or_else(|| env.storage().temporary().get(&key))?;
         let now = env.ledger().timestamp();
         Some(now.saturating_sub(entry.cached_at))
     }
@@ -1190,9 +1208,12 @@ impl AnchorKitContract {
     pub fn refresh_metadata_cache(env: Env, anchor: Address) -> AnchorMetadata {
         Self::require_admin(&env);
         let key = StorageKey::MetadataCache(anchor.clone());
-        let entry: MetadataCache = env.storage().temporary().get(&key)
+        let entry: MetadataCache = env.storage().persistent().get(&key)
+            .or_else(|| env.storage().temporary().get(&key))
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::CacheNotFound));
         let metadata = entry.metadata.clone();
+        // Remove from whichever storage tier holds the entry.
+        env.storage().persistent().remove(&key);
         env.storage().temporary().remove(&key);
 
         // Issue #276: remove from CACHED_ANCHORS set


### PR DESCRIPTION
closes #504 


ttl_seconds=0 signals "never expire at app level", but storing in temporary Soroban storage contradicts that — the network can still evict the entry when its ledger TTL expires.

Fix: route ttl_seconds=0 writes to persistent storage (PERSISTENT_TTL). Update get_cached_metadata, get_cache_age_seconds, and refresh_metadata_cache to check persistent storage first, then temporary, so both entry types are handled transparently.

