### PR TITLE
fix: tighten config validation and docs

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -29,6 +29,8 @@ Open `configs/my-anchor.json` and replace the placeholder values:
 | `attestors[0].address` | Your attestor's Stellar public key (starts with `G`) |
 | `attestors[0].endpoint` | Your attestor's HTTPS endpoint URL |
 
+Contract interactions are performed through Soroban transactions, not direct JavaScript session helpers. Use the Soroban CLI or the Stellar JavaScript SDK's contract invocation APIs when you need to call the contract.
+
 ## 3. Validate your config
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -132,26 +132,21 @@ AnchorKit now includes comprehensive session management and operation tracing to
 
 ### Quick Example
 
-```javascript
-// Create a session
-const sessionId = await contract.create_session(userAddress);
+Use Soroban transactions to invoke contract methods. For example, with the CLI:
 
-// Perform operations within the session
-const attestationId = await contract.submit_attestation_with_session(
-    sessionId,
-    issuer,
-    subject,
-    timestamp,
-    payloadHash,
-    signature
-);
-
-// Verify session completeness
-const operationCount = await contract.get_session_operation_count(sessionId);
-
-// Retrieve audit logs
-const auditLog = await contract.get_audit_log(0);
+```bash
+soroban contract invoke \
+    --id <CONTRACT_ID> \
+    --source <ADMIN_ACCOUNT> \
+    --network testnet \
+    -- \
+    register_attestor \
+    --attestor <ATTESTOR_ADDRESS> \
+    --sep10-token <JWT> \
+    --sep10-issuer <ISSUER_ADDRESS>
 ```
+
+If you prefer the Stellar JavaScript SDK, use its contract invocation API instead of direct async session helpers.
 
 ## Documentation
 
@@ -173,10 +168,10 @@ const auditLog = await contract.get_audit_log(0);
 - **[docs/features/WEBHOOK_MIDDLEWARE.md](./docs/features/WEBHOOK_MIDDLEWARE.md)** - Webhook middleware
 - **[docs/features/WEBHOOK_MONITOR.md](./docs/features/WEBHOOK_MONITOR.md)** - Webhook monitoring
 - **[docs/features/TRANSACTION_STATE_TRACKER.md](./docs/features/TRANSACTION_STATE_TRACKER.md)** - Transaction state tracking
-- **[docs/features/SEP10_AUTH.md](./docs/features/SEP10_AUTH.md)** - SEP-10 authentication
 - **[docs/features/SDK_CONFIG.md](./docs/features/SDK_CONFIG.md)** - SDK configuration
 - **[docs/features/STATUS_MONITOR.md](./docs/features/STATUS_MONITOR.md)** - Status monitoring
 - **[docs/features/ROUTING_STRATEGY.md](./docs/features/ROUTING_STRATEGY.md)** - Routing strategy selection (`route_transaction`)
+- **[docs/features/SEP10_AUTH.md](./docs/features/SEP10_AUTH.md)** - SEP-10 authentication; this is the canonical copy for the topic
 
 ### Guides
 - **[docs/guides/DOCTOR_COMMAND.md](./docs/guides/DOCTOR_COMMAND.md)** - CLI doctor command and environment diagnostics

--- a/SEP10_AUTH.md
+++ b/SEP10_AUTH.md
@@ -1,9 +1,0 @@
-# SEP-10 Authentication
-
-The SEP-10 documentation for AnchorKit (off-chain flow **and** on-chain Soroban JWT verification) lives in the docs tree:
-
-**[docs/features/SEP10_AUTH.md](docs/features/SEP10_AUTH.md)**
-
-That file is the **canonical** copy and includes `set_sep10_jwt_verifying_key`, `verify_sep10_token`, `register_attestor`, and `ErrorCode::InvalidSep10Token`.
-
-Also indexed from [docs/README.md](docs/README.md).

--- a/config_schema.json
+++ b/config_schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AnchorKit Configuration Schema",
   "type": "object",
-  "required": ["contract", "attestors"],
+  "required": ["contract", "attestors", "sessions"],
   "properties": {
     "contract": {
       "type": "object",
@@ -85,6 +85,7 @@
     },
     "sessions": {
       "type": "object",
+      "required": ["enable_session_tracking", "session_timeout_seconds", "operations_per_session", "audit_log_retention_days"],
       "properties": {
         "enable_session_tracking": {
           "type": "boolean"

--- a/configs/testnet-example.json
+++ b/configs/testnet-example.json
@@ -20,6 +20,7 @@
   "sessions": {
     "enable_session_tracking": true,
     "session_timeout_seconds": 3600,
-    "operations_per_session": 100
+    "operations_per_session": 100,
+    "audit_log_retention_days": 30
   }
 }

--- a/validate_config.py
+++ b/validate_config.py
@@ -12,6 +12,45 @@ from typing import Dict, List, Any
 class ValidationError(Exception):
     pass
 
+def validate_required_fields(config: Dict[str, Any]) -> None:
+    """Validate the required deployment configuration structure."""
+    if "contract" not in config:
+        raise ValidationError("Missing required top-level section: contract")
+
+    if "attestors" not in config:
+        raise ValidationError("Missing required top-level section: attestors")
+
+    if "sessions" not in config:
+        raise ValidationError("Missing required top-level section: sessions")
+
+    contract = config["contract"]
+    for field in ("name", "version", "network"):
+        if field not in contract:
+            raise ValidationError(f"Missing required contract field: {field}")
+
+    attestors = config["attestors"]
+    if "registry" not in attestors:
+        raise ValidationError("Missing required attestor field: registry")
+
+    registry = attestors["registry"]
+    if not registry:
+        raise ValidationError("Attestor registry cannot be empty")
+
+    for index, attestor in enumerate(registry):
+        for field in ("name", "address", "endpoint", "role", "enabled"):
+            if field not in attestor:
+                raise ValidationError(f"Attestor {index}: missing required field {field}")
+
+    sessions = config["sessions"]
+    for field in (
+        "enable_session_tracking",
+        "session_timeout_seconds",
+        "operations_per_session",
+        "audit_log_retention_days",
+    ):
+        if field not in sessions:
+            raise ValidationError(f"Missing required session field: {field}")
+
 def validate_contract_config(config: Dict[str, Any]) -> None:
     """Validate contract configuration"""
     name = config.get("name", "")
@@ -81,6 +120,8 @@ def validate_json_config(file_path: Path) -> None:
     
     with open(file_path) as f:
         config = json.load(f)
+
+    validate_required_fields(config)
     
     if "contract" in config:
         validate_contract_config(config["contract"])


### PR DESCRIPTION
This PR tightens config validation, updates the testnet sample config, and corrects docs that were misleading or duplicated.

What changed:

Added required-field enforcement to [config_schema.json](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [validate_config.py](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Expanded [testnet-example.json](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with the missing session retention field
Replaced the JavaScript session-helper example in [README.md](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with Soroban CLI-oriented guidance
Added a clearer note in [QUICK_START.md](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) about contract invocation
Removed the duplicate root [SEP10_AUTH.md](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in favor of [SEP10_AUTH.md](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Fixes #536
Fixes #537
Fixes #538
Fixes #539
