### PR TITLE
Fix cache_metadata idempotency for unchanged metadata

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1253,11 +1253,8 @@ impl AnchorKitContract {
         // ttl_seconds=0 entries live in persistent storage (never network-evicted);
         // all other entries live in temporary storage.
         let key = StorageKey::MetadataCache(anchor.clone());
-        let existing: Option<MetadataCache> = if ttl_seconds == 0 {
-            env.storage().persistent().get(&key)
-        } else {
-            env.storage().temporary().get(&key)
-        };
+        let existing: Option<MetadataCache> = env.storage().persistent().get(&key)
+            .or_else(|| env.storage().temporary().get(&key));
         if let Some(existing) = existing {
             let m = &existing.metadata;
             if m.anchor == metadata.anchor


### PR DESCRIPTION
This PR fixes issue #502 by updating  to read the existing metadata cache from both persistent and temporary storage before deciding to write. If the metadata is unchanged, the function now returns early and avoids unnecessary storage writes and TTL extension.

- Reads existing cache entry from both storage modes
- Compares metadata before writing
- Preserves idempotent behavior expected by 

closes #502