### PR TITLE
Validate cache_metadata reputation and uptime input ranges

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1252,6 +1252,9 @@ impl AnchorKitContract {
         // Issue #259: skip write if metadata is unchanged.
         // ttl_seconds=0 entries live in persistent storage (never network-evicted);
         // all other entries live in temporary storage.
+        if metadata.reputation_score > 10000 || metadata.uptime_percentage > 10000 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
         let key = StorageKey::MetadataCache(anchor.clone());
         let existing: Option<MetadataCache> = if ttl_seconds == 0 {
             env.storage().persistent().get(&key)

--- a/src/metadata_cache_tests.rs
+++ b/src/metadata_cache_tests.rs
@@ -75,6 +75,40 @@ mod metadata_cache_tests {
     }
 
     #[test]
+    #[should_panic(expected = "ValidationError")]
+    fn test_cache_metadata_reputation_score_must_be_at_most_10000() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor = Address::generate(&env);
+        client.initialize(&admin, &100_u64, &None);
+
+        let mut meta = sample_metadata(&env, &anchor);
+        meta.reputation_score = 10001;
+        client.cache_metadata(&anchor, &meta, &3600u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "ValidationError")]
+    fn test_cache_metadata_uptime_percentage_must_be_at_most_10000() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor = Address::generate(&env);
+        client.initialize(&admin, &100_u64, &None);
+
+        let mut meta = sample_metadata(&env, &anchor);
+        meta.uptime_percentage = 10001;
+        client.cache_metadata(&anchor, &meta, &3600u64);
+    }
+
+    #[test]
     fn test_cache_expiration() {
         let env = make_env();
         set_ledger(&env, 0);


### PR DESCRIPTION
Closes #501

---

Fixes issue #501 by validating that  and  are each at most 10000 before caching metadata. Invalid values now panic with . Added regression tests for both out-of-range fields.