### PR TITLE
docs: fix RETRY_BACKOFF.md field names to match RetryConfig struct

### DIFF
--- a/docs/features/RETRY_BACKOFF.md
+++ b/docs/features/RETRY_BACKOFF.md
@@ -29,7 +29,8 @@ The helper `is_retryable(code)` classifies only transient, availability, and cac
 - `NoQuotesAvailable`
 - `CacheExpired`
 - `CacheNotFound`
-- `RateLimitExceeded`
+
+**Note**: `RateLimitExceeded` is intentionally **NOT** retryable. The rate window only clears after `window_length` ledgers, so retrying in a tight backoff loop would burn through every attempt and still fail. Callers that need to recover from a rate limit should wait for the window to reset (or call the admin reset path) before issuing the next request.
 
 All other `ErrorCode` values are considered non-retryable and should stop immediately.
 
@@ -54,7 +55,7 @@ All other `ErrorCode` values are considered non-retryable and should stop immedi
 | `NoQuotesAvailable` | Yes | Transient quote availability |
 | `ServicesNotConfigured` | Yes | Anchor not ready yet |
 | `ValidationError` | No | Invalid response payload |
-| `RateLimitExceeded` | Yes | Back off and retry later |
+| `RateLimitExceeded` | No | Rate window only clears after window_length ledgers; tight retry loops will fail |
 | `NotInitialized` | No | Contract not ready |
 | `AttestationNotFound` | Yes | Data may become available soon |
 | `InvalidSep10Token` | No | Auth failure |
@@ -73,24 +74,13 @@ All other `ErrorCode` values are considered non-retryable and should stop immedi
 
 ## Retryable Errors
 
-The following errors are automatically retried:
-
-### Network Failures
-- `TransportError` - General network/transport failures
-- `TransportTimeout` - Request timeouts
-- `EndpointNotFound` - Endpoint temporarily unavailable
-
-### Rate Limiting
-- `RateLimitExceeded` - Rate limit exceeded (429)
-- `ProtocolRateLimitExceeded` - Protocol-level rate limiting
+The following errors are automatically retried by `is_retryable`:
 
 ### Transient Failures
 - `ServicesNotConfigured` - Service temporarily unavailable
 - `AttestationNotFound` - Attestation not yet available
-- `SessionNotFound` - Session not yet created
 - `StaleQuote` - Quote expired, can fetch fresh
 - `NoQuotesAvailable` - No quotes currently available
-- `AnchorMetadataNotFound` - Metadata not yet cached
 - `CacheExpired` - Cache expired, can refresh
 - `CacheNotFound` - Cache miss, can fetch
 
@@ -98,16 +88,22 @@ The following errors are automatically retried:
 
 The following errors are NOT retried (permanent failures):
 
-- `InvalidConfig` - Configuration error
+- `AlreadyInitialized` - Permanent contract state error
+- `AttestorAlreadyRegistered` - Duplicate registration
+- `AttestorNotRegistered` - Invalid anchor state
 - `UnauthorizedAttestor` - Authentication failure
-- `TransportUnauthorized` - Authorization failure
+- `InvalidTimestamp` - Bad request data
+- `ReplayAttack` - Security violation
 - `InvalidQuote` - Invalid quote data
-- `InvalidTimestamp` - Invalid timestamp
-- `ReplayAttack` - Replay attack detected
-- `ComplianceNotMet` - Compliance check failed
-- `CredentialExpired` - Expired credentials
-- `ProtocolError` - Protocol violation
-- `ProtocolInvalidPayload` - Invalid payload format
+- `InvalidServiceType` - Invalid request parameter
+- `InvalidTransactionIntent` - Invalid transaction shape
+- `ComplianceNotMet` - Permanent policy failure
+- `InvalidEndpointFormat` - Bad endpoint configuration
+- `ValidationError` - Invalid response payload
+- `RateLimitExceeded` - Rate window requires ledger-based reset
+- `NotInitialized` - Contract not ready
+- `InvalidSep10Token` - Authentication failure
+- `StorageCorrupted` - Persistent on-chain corruption
 
 ## Configuration
 
@@ -118,7 +114,7 @@ use anchorkit::retry::RetryConfig;
 
 let config = RetryConfig::default();
 // max_attempts: 3
-// initial_delay_ms: 100
+// base_delay_ms: 100
 // max_delay_ms: 5000
 // backoff_multiplier: 2
 ```
@@ -131,7 +127,7 @@ use anchorkit::retry::RetryConfig;
 // Aggressive: many attempts, short delays
 let aggressive = RetryConfig::new(
     10,    // max_attempts
-    10,    // initial_delay_ms
+    10,    // base_delay_ms
     1000,  // max_delay_ms
     2      // backoff_multiplier
 );
@@ -139,7 +135,7 @@ let aggressive = RetryConfig::new(
 // Conservative: few attempts, long delays
 let conservative = RetryConfig::new(
     3,     // max_attempts
-    1000,  // initial_delay_ms
+    1000,  // base_delay_ms
     10000, // max_delay_ms
     3      // backoff_multiplier
 );
@@ -147,7 +143,7 @@ let conservative = RetryConfig::new(
 // Custom for rate limiting: longer delays
 let rate_limit = RetryConfig::new(
     5,     // max_attempts
-    500,   // initial_delay_ms
+    500,   // base_delay_ms
     30000, // max_delay_ms (30 seconds)
     3      // backoff_multiplier
 );
@@ -178,113 +174,105 @@ assert_eq!(attempts, 1);
 assert!(matches!(result, Err(err) if err.code == ErrorCode::InvalidQuote));
 ```
 
-### Basic Retry
+### Basic Retry with Custom Sleep
 
 ```rust
-use anchorkit::retry::{RetryConfig, RetryEngine};
+use anchorkit::retry::{RetryConfig, retry_with_backoff};
 
 let config = RetryConfig::default();
-let engine = RetryEngine::new(config);
 
-let result = engine.execute(|attempt| {
-    // Your operation here
-    // Returns Ok(value) on success or Err(error) on failure
-    make_network_request()
-});
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        println!("Attempt {}", attempt);
+        // Your operation here
+        make_network_request()
+    },
+    |e| is_retryable_error(e),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 
-if result.is_success() {
-    println!("Success after {} attempts", result.attempts);
-    println!("Total delay: {}ms", result.total_delay_ms);
-    let value = result.value.unwrap();
-} else {
-    println!("Failed after {} attempts", result.attempts);
-    let error = result.error.unwrap();
+match result {
+    Ok(value) => println!("Success: {:?}", value),
+    Err(error) => println!("Failed: {:?}", error),
 }
 ```
 
-### With Transport Layer
+### Retryable Error Handling
 
 ```rust
-use anchorkit::{
-    retry::{RetryConfig, RetryEngine},
-    transport::{AnchorTransport, TransportRequest, TransportResponse},
-};
+use anchorkit::retry::{retry_with_backoff, RetryConfig, is_retryable};
 
 let config = RetryConfig::new(5, 100, 5000, 2);
-let engine = RetryEngine::new(config);
 
-let result = engine.execute(|attempt| {
-    println!("Attempt {}", attempt + 1);
-    
-    let request = TransportRequest::GetQuote {
-        endpoint: endpoint.clone(),
-        base_asset: base.clone(),
-        quote_asset: quote.clone(),
-        amount: 1000,
-    };
-    
-    transport.send_request(&env, request)
-});
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        println!("Attempt {}", attempt + 1);
+        fetch_anchor_data()
+    },
+    |e| is_retryable(e.code as u32),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 
-match result.value {
-    Some(TransportResponse::Quote(quote)) => {
-        println!("Got quote: rate={}", quote.rate);
-    }
-    _ => {
-        println!("Failed to get quote: {:?}", result.error);
-    }
+match result {
+    Ok(data) => println!("Got data: {:?}", data),
+    Err(error) => println!("Failed after retries: {:?}", error),
 }
 ```
 
-### Rate Limit Handling
+### Custom Retry Logic
 
 ```rust
-use anchorkit::retry::{RetryConfig, RetryEngine};
+use anchorkit::retry::{RetryConfig, retry_with_backoff};
 
-// Configure longer delays for rate limiting
+// Configure longer delays for specific scenarios
 let config = RetryConfig::new(
     5,     // max_attempts
-    500,   // initial_delay_ms
+    500,   // base_delay_ms
     30000, // max_delay_ms (30 seconds)
     3      // backoff_multiplier (aggressive backoff)
 );
 
-let engine = RetryEngine::new(config);
-
-let result = engine.execute(|attempt| {
-    match make_api_call() {
-        Ok(response) => Ok(response),
-        Err(Error::RateLimitExceeded) => {
-            println!("Rate limited, backing off...");
-            Err(Error::RateLimitExceeded)
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        match make_api_call() {
+            Ok(response) => Ok(response),
+            Err(e) if should_retry(&e) => {
+                println!("Retryable error on attempt {}, backing off...", attempt + 1);
+                Err(e)
+            }
+            Err(e) => Err(e),
         }
-        Err(e) => Err(e),
-    }
-});
+    },
+    |e| should_retry(e),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 ```
 
-### Network Failure Recovery
+### Transient Failure Recovery
 
 ```rust
-use anchorkit::retry::{RetryConfig, RetryEngine};
+use anchorkit::retry::{RetryConfig, retry_with_backoff, is_retryable};
 
 let config = RetryConfig::new(4, 100, 5000, 2);
-let engine = RetryEngine::new(config);
 
-let result = engine.execute(|attempt| {
-    match fetch_anchor_data() {
-        Ok(data) => Ok(data),
-        Err(Error::TransportTimeout) => {
-            println!("Timeout on attempt {}, retrying...", attempt + 1);
-            Err(Error::TransportTimeout)
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        match fetch_anchor_data() {
+            Ok(data) => Ok(data),
+            Err(e) if is_retryable(e.code as u32) => {
+                println!("Transient error on attempt {}, retrying...", attempt + 1);
+                Err(e)
+            }
+            Err(e) => Err(e),
         }
-        Err(Error::TransportError) => {
-            println!("Network error on attempt {}, retrying...", attempt + 1);
-            Err(Error::TransportError)
-        }
-        Err(e) => Err(e),
-    }
-});
+    },
+    |e| is_retryable(e.code as u32),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 ```
 
 ## Backoff Timing
@@ -292,65 +280,64 @@ let result = engine.execute(|attempt| {
 The delay between retries follows an exponential pattern:
 
 ```
-Attempt 0: 0ms (immediate)
-Attempt 1: initial_delay_ms
-Attempt 2: initial_delay_ms * multiplier^1
-Attempt 3: initial_delay_ms * multiplier^2
-Attempt 4: initial_delay_ms * multiplier^3
+Attempt 0: base_delay_ms * multiplier^0 + jitter
+Attempt 1: base_delay_ms * multiplier^1 + jitter
+Attempt 2: base_delay_ms * multiplier^2 + jitter
+Attempt 3: base_delay_ms * multiplier^3 + jitter
 ...
+(capped at max_delay_ms)
 ```
+
+The jitter is derived deterministically from the attempt number and adds randomness up to `base_delay_ms / 2` to help desynchronize retry storms across clients.
 
 ### Example with Default Config
 
 ```
 max_attempts: 3
-initial_delay_ms: 100
+base_delay_ms: 100
 backoff_multiplier: 2
 
-Attempt 0: 0ms
-Attempt 1: 100ms
-Attempt 2: 200ms
-Total: 300ms
+Attempt 0: ~100ms (100 * 2^0 + jitter)
+Attempt 1: ~200ms (100 * 2^1 + jitter)
+Attempt 2: ~400ms (100 * 2^2 + jitter)
 ```
 
 ### Example with Aggressive Config
 
 ```
 max_attempts: 5
-initial_delay_ms: 50
+base_delay_ms: 50
 backoff_multiplier: 3
 
-Attempt 0: 0ms
-Attempt 1: 50ms
-Attempt 2: 150ms
-Attempt 3: 450ms
-Attempt 4: 1350ms
-Total: 2000ms
+Attempt 0: ~50ms (50 * 3^0 + jitter)
+Attempt 1: ~150ms (50 * 3^1 + jitter)
+Attempt 2: ~450ms (50 * 3^2 + jitter)
+Attempt 3: ~1350ms (50 * 3^3 + jitter)
+Attempt 4: ~4050ms (50 * 3^4 + jitter)
 ```
 
 ### Example with Rate Limit Config
 
 ```
 max_attempts: 5
-initial_delay_ms: 500
+base_delay_ms: 500
 backoff_multiplier: 3
 max_delay_ms: 30000
 
-Attempt 0: 0ms
-Attempt 1: 500ms
-Attempt 2: 1500ms
-Attempt 3: 4500ms
-Attempt 4: 13500ms
-Total: 20000ms
+Attempt 0: ~500ms (500 * 3^0 + jitter)
+Attempt 1: ~1500ms (500 * 3^1 + jitter)
+Attempt 2: ~4500ms (500 * 3^2 + jitter)
+Attempt 3: ~13500ms (500 * 3^3 + jitter)
+Attempt 4: ~30000ms (capped at max_delay_ms)
 ```
 
 ## Best Practices
 
 ### 1. Choose Appropriate Strategy
 
-- **Network failures**: Moderate attempts (3-5), short delays (100-500ms)
-- **Rate limiting**: Fewer attempts (3-4), longer delays (500-1000ms), higher multiplier (3-4)
-- **Server errors (5xx)**: Moderate attempts (3-5), moderate delays (200-500ms)
+- **Transient failures**: Moderate attempts (3-5), short delays (100-500ms)
+- **Service unavailability**: Fewer attempts (3-4), longer delays (500-1000ms), higher multiplier (3)
+- **Cache misses**: Moderate attempts (3-5), moderate delays (200-500ms)
 
 ### 2. Set Reasonable Max Delays
 
@@ -362,35 +349,43 @@ let user_facing = RetryConfig::new(3, 100, 2000, 2);
 let background = RetryConfig::new(5, 500, 30000, 3);
 ```
 
-### 3. Monitor Retry Metrics
+### 3. Provide Custom Sleep Function
 
 ```rust
-let result = engine.execute(|attempt| {
-    // Your operation
-});
+// For synchronous code
+let result = retry_with_backoff(
+    &config,
+    |attempt| operation(attempt),
+    |e| is_retryable(e.code as u32),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 
-// Log retry metrics
-println!("Attempts: {}", result.attempts);
-println!("Total delay: {}ms", result.total_delay_ms);
-println!("Success: {}", result.is_success());
+// For testing (no actual sleep)
+let result = retry_with_backoff(
+    &config,
+    |attempt| operation(attempt),
+    |e| is_retryable(e.code as u32),
+    |_| {}, // no-op sleep for tests
+);
 ```
 
 ### 4. Handle Non-Retryable Errors
 
 ```rust
-let result = engine.execute(|attempt| {
-    match operation() {
-        Err(Error::InvalidConfig) => {
-            // Non-retryable, fail fast
-            return Err(Error::InvalidConfig);
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        match operation() {
+            Err(e) if !is_retryable(e.code as u32) => {
+                // Non-retryable, fail fast
+                return Err(e);
+            }
+            other => other,
         }
-        Err(Error::TransportTimeout) => {
-            // Retryable, will retry
-            return Err(Error::TransportTimeout);
-        }
-        Ok(value) => Ok(value),
-    }
-});
+    },
+    |e| is_retryable(e.code as u32),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 ```
 
 ## Testing
@@ -402,54 +397,37 @@ The retry logic includes comprehensive tests:
 cargo test retry --lib
 
 # Run specific test categories
-cargo test test_network_failure --lib
-cargo test test_rate_limit --lib
-cargo test test_exponential_backoff --lib
+cargo test test_success_on_first_try --lib
+cargo test test_exhausted_retries --lib
+cargo test test_delay_increases_exponentially --lib
 ```
 
-## Integration with Transport
+## Integration with Application Code
 
-The retry logic is designed to work seamlessly with the transport layer:
+The retry logic is designed to work with any operation that returns a `Result`:
 
 ```rust
-use anchorkit::{
-    retry::{RetryConfig, RetryEngine},
-    transport::{AnchorTransport, MockTransport, TransportRequest},
-};
+use anchorkit::retry::{RetryConfig, retry_with_backoff, is_retryable};
 
-let mut transport = MockTransport::new();
 let config = RetryConfig::default();
-let engine = RetryEngine::new(config);
 
-let result = engine.execute(|_| {
-    transport.send_request(&env, request.clone())
-});
-```
-
-## Error Classification
-
-To check if an error is retryable:
-
-```rust
-use anchorkit::retry::is_retryable_error;
-use anchorkit::errors::Error;
-
-if is_retryable_error(&Error::TransportTimeout) {
-    println!("This error will be retried");
-}
-
-if !is_retryable_error(&Error::InvalidConfig) {
-    println!("This error will NOT be retried");
-}
+let result = retry_with_backoff(
+    &config,
+    |attempt| {
+        // Your operation that might fail
+        perform_operation(attempt)
+    },
+    |e| is_retryable(e.code as u32),
+    |delay_ms| std::thread::sleep(std::time::Duration::from_millis(delay_ms)),
+);
 ```
 
 ## Summary
 
 - ✅ Exponential backoff with configurable parameters
 - ✅ Smart error classification (retryable vs non-retryable)
-- ✅ Network failure handling (timeouts, transport errors)
-- ✅ Rate limit handling (429 responses)
-- ✅ 5xx server error handling
+- ✅ Transient failure handling (service unavailability, cache misses)
 - ✅ Configurable retry strategies
+- ✅ Jitter to prevent retry storms
 - ✅ Comprehensive test coverage
-- ✅ Integration with transport layer
+- ✅ Simple function-based API with `retry_with_backoff`


### PR DESCRIPTION
# Fix RETRY_BACKOFF.md Documentation Discrepancies

## Summary

This PR fixes documentation discrepancies in `docs/features/RETRY_BACKOFF.md` where field names and API references did not match the actual `RetryConfig` struct implementation in `src/retry.rs`.

## Changes Made

### Field Name Corrections
- ✅ Changed `initial_delay_ms` → `base_delay_ms` throughout all examples
- ✅ Updated all configuration examples to use correct field names
- ✅ Fixed default configuration documentation

### Retryability Classification
- ✅ Corrected `RateLimitExceeded` from retryable to **non-retryable**
- ✅ Added explanation: rate window only clears after `window_length` ledgers
- ✅ Updated retryability summary table

### API Corrections
- ✅ Removed references to non-existent `RetryEngine` API
- ✅ Updated all code examples to use `retry_with_backoff` function
- ✅ Fixed function signatures to match actual implementation

### Error Classification Updates
- ✅ Removed non-existent error types (`TransportError`, `TransportTimeout`, `EndpointNotFound`, etc.)
- ✅ Updated retryable errors list to match `is_retryable` implementation
- ✅ Updated non-retryable errors list with actual error codes

### Timing Documentation
- ✅ Fixed backoff timing examples to include jitter
- ✅ Corrected delay calculation formulas
- ✅ Updated timing examples to reflect actual behavior

### Code Examples
- ✅ Replaced all `RetryEngine` examples with `retry_with_backoff`
- ✅ Added proper sleep function parameter examples
- ✅ Updated integration examples to match actual API

## Testing

All changes are documentation-only. The actual implementation in `src/retry.rs` remains unchanged and all tests continue to pass:

```bash
cargo test retry --lib
```

## Files Changed

- `docs/features/RETRY_BACKOFF.md` - Fixed field names, API references, and error classifications

## Verification

Verified against `src/retry.rs`:
- ✅ `RetryConfig` struct fields: `max_attempts`, `base_delay_ms`, `max_delay_ms`, `backoff_multiplier`
- ✅ Default values: `max_attempts: 3`, `base_delay_ms: 100`, `max_delay_ms: 5000`, `backoff_multiplier: 2`
- ✅ `is_retryable` function returns `true` only for: `ServicesNotConfigured`, `AttestationNotFound`, `StaleQuote`, `NoQuotesAvailable`, `CacheExpired`, `CacheNotFound`
- ✅ `retry_with_backoff` function signature matches documentation

Closes #535
