### PR TITLE
feat(smart-contracts): fix #399 yield rewards and #391 event hub access

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     StorageKey,
     key_admin, key_counter, key_session_counter, key_quote_counter,
     key_audit_counter, key_anchor_list, key_health_threshold, key_replay_window,
-    key_audit_log_offset,
+    key_audit_log_offset, key_event_hub_counter,
 };
 
 // ---------------------------------------------------------------------------
@@ -19,8 +19,9 @@ use crate::storage::{
 
 pub use crate::types::{
     AnchorMetadata, AnchorServices, AssetInfo, Attestation, AuditLog, CapabilitiesCache,
-    CachedToml, FiatCurrency, HealthStatus, MetadataCache, OperationContext, Quote, RequestId,
-    RoutingOptions, RoutingRequest, Session, StellarToml, TracingSpan,
+    CachedToml, EventHubMessage, FarmerPosition, FiatCurrency, HealthStatus, MetadataCache,
+    OperationContext, Quote, RequestId, RewardClaim, RoutingOptions, RoutingRequest, Session,
+    StellarToml, TracingSpan, YieldFarmState,
     SERVICE_DEPOSITS, SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_KYC, ServiceType,
 };
 
@@ -126,6 +127,28 @@ struct AttestorRegistered(Address);
 #[derive(Clone)]
 struct AttestorRevoked(Address);
 
+#[contracttype]
+#[derive(Clone)]
+struct YieldFarmConfigured {
+    reward_rate: u128,
+    period_finish: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct YieldFarmStakeChanged {
+    farmer: Address,
+    amount: u128,
+    total_staked: u128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct EventHubAccessChanged {
+    publisher: Address,
+    allowed: bool,
+}
+
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
 //
@@ -147,6 +170,8 @@ const INSTANCE_TTL: u32 = 518_400;
 const SESSION_TTL: u64 = 86_400;
 /// Session storage TTL in ledgers (~24 hours at 5s/ledger).
 const SESSION_LEDGER_TTL: u32 = 17_280;
+/// Fixed-point scale for reward-per-token accounting.
+const REWARD_SCALE: u128 = 1_000_000_000_000;
 
 fn pending_admin_key(env: &Env) -> soroban_sdk::Vec<soroban_sdk::Symbol> {
     soroban_sdk::vec![env, symbol_short!("PADMIN")]
@@ -1308,7 +1333,8 @@ impl AnchorKitContract {
     pub fn get_cache_age_seconds(env: Env, anchor: Address) -> Result<u64, ErrorCode> {
         let key = StorageKey::MetadataCache(anchor);
         let entry: MetadataCache = env.storage().persistent().get(&key)
-            .or_else(|| env.storage().temporary().get(&key))?;
+            .or_else(|| env.storage().temporary().get(&key))
+            .ok_or(ErrorCode::CacheNotFound)?;
         let now = env.ledger().timestamp();
         Ok(now.saturating_sub(entry.cached_at))
     }
@@ -1751,7 +1777,7 @@ impl AnchorKitContract {
             candidates.push_back(quote);
 
             // Stop adding candidates if we've reached max_anchors limit
-            if options.max_anchors > 0 && candidates.len() >= options.max_anchors as usize {
+            if options.max_anchors > 0 && candidates.len() >= options.max_anchors {
                 break;
             }
         }
@@ -1873,6 +1899,201 @@ impl AnchorKitContract {
         );
 
         best
+    }
+
+    // -----------------------------------------------------------------------
+    // Yield Farming
+    // -----------------------------------------------------------------------
+
+    /// Configure the singleton yield farm emission schedule.
+    ///
+    /// Rewards use a global reward-per-token accumulator, so stake, withdraw,
+    /// claim, and schedule updates are O(1). Emissions that occur while
+    /// `total_staked == 0` are not retroactively assigned to later stakers.
+    pub fn configure_yield_farm(env: Env, reward_rate: u128, period_finish: u64) {
+        Self::require_admin(&env);
+        let now = env.ledger().timestamp();
+        if reward_rate == 0 || period_finish <= now {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        let mut state = Self::current_yield_farm_state(&env);
+        state = Self::updated_yield_farm_state(&env, state);
+        state.reward_rate = reward_rate;
+        state.last_update_time = now;
+        state.period_finish = period_finish;
+
+        Self::store_yield_farm_state(&env, &state);
+        env.events().publish(
+            (symbol_short!("yfarming"), symbol_short!("config")),
+            YieldFarmConfigured { reward_rate, period_finish },
+        );
+    }
+
+    pub fn get_yield_farm_state(env: Env) -> YieldFarmState {
+        Self::updated_yield_farm_state(&env, Self::current_yield_farm_state(&env))
+    }
+
+    pub fn get_farmer_position(env: Env, farmer: Address) -> FarmerPosition {
+        let state = Self::get_yield_farm_state(env.clone());
+        let position = Self::current_farmer_position(&env, &farmer);
+        Self::updated_farmer_position(&env, position, &state)
+    }
+
+    pub fn stake_yield_farm(env: Env, farmer: Address, amount: u128) -> FarmerPosition {
+        farmer.require_auth();
+        if amount == 0 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        let mut state = Self::updated_yield_farm_state(&env, Self::current_yield_farm_state(&env));
+        let mut position = Self::updated_farmer_position(
+            &env,
+            Self::current_farmer_position(&env, &farmer),
+            &state,
+        );
+
+        position.staked = position
+            .staked
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError));
+        state.total_staked = state
+            .total_staked
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError));
+
+        Self::store_yield_farm_state(&env, &state);
+        Self::store_farmer_position(&env, &farmer, &position);
+        env.events().publish(
+            (symbol_short!("yfarming"), symbol_short!("stake")),
+            YieldFarmStakeChanged {
+                farmer,
+                amount,
+                total_staked: state.total_staked,
+            },
+        );
+        position
+    }
+
+    pub fn withdraw_yield_farm(env: Env, farmer: Address, amount: u128) -> FarmerPosition {
+        farmer.require_auth();
+        if amount == 0 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        let mut state = Self::updated_yield_farm_state(&env, Self::current_yield_farm_state(&env));
+        let mut position = Self::updated_farmer_position(
+            &env,
+            Self::current_farmer_position(&env, &farmer),
+            &state,
+        );
+        if amount > position.staked {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        position.staked -= amount;
+        state.total_staked -= amount;
+
+        Self::store_yield_farm_state(&env, &state);
+        Self::store_farmer_position(&env, &farmer, &position);
+        env.events().publish(
+            (symbol_short!("yfarming"), symbol_short!("withdraw")),
+            YieldFarmStakeChanged {
+                farmer,
+                amount,
+                total_staked: state.total_staked,
+            },
+        );
+        position
+    }
+
+    pub fn claim_yield_rewards(env: Env, farmer: Address) -> RewardClaim {
+        farmer.require_auth();
+
+        let state = Self::updated_yield_farm_state(&env, Self::current_yield_farm_state(&env));
+        let mut position = Self::updated_farmer_position(
+            &env,
+            Self::current_farmer_position(&env, &farmer),
+            &state,
+        );
+        let amount = position.pending_rewards;
+        position.pending_rewards = 0;
+
+        Self::store_yield_farm_state(&env, &state);
+        Self::store_farmer_position(&env, &farmer, &position);
+
+        let claim = RewardClaim {
+            farmer: farmer.clone(),
+            amount,
+            claimed_at: env.ledger().timestamp(),
+        };
+        env.events().publish(
+            (symbol_short!("yfarming"), symbol_short!("claim")),
+            claim.clone(),
+        );
+        claim
+    }
+
+    // -----------------------------------------------------------------------
+    // Event Hub
+    // -----------------------------------------------------------------------
+
+    pub fn set_event_hub_publisher(env: Env, publisher: Address, allowed: bool) {
+        Self::require_admin(&env);
+        let key = StorageKey::EventHubPublisher(publisher.clone());
+        if allowed {
+            env.storage().persistent().set(&key, &true);
+            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        } else {
+            env.storage().persistent().remove(&key);
+        }
+        env.events().publish(
+            (symbol_short!("evthub"), symbol_short!("access")),
+            EventHubAccessChanged { publisher, allowed },
+        );
+    }
+
+    pub fn is_event_hub_publisher(env: Env, publisher: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get::<_, bool>(&StorageKey::EventHubPublisher(publisher))
+            .unwrap_or(false)
+    }
+
+    pub fn publish_hub_event(
+        env: Env,
+        publisher: Address,
+        topic: String,
+        data: Bytes,
+    ) -> EventHubMessage {
+        Self::require_event_hub_publisher(&env, &publisher);
+        publisher.require_auth();
+        if topic.len() == 0 || data.len() == 0 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        let id = Self::next_event_hub_id(&env);
+        let message = EventHubMessage {
+            event_id: id,
+            publisher: publisher.clone(),
+            topic,
+            data,
+            published_at: env.ledger().timestamp(),
+        };
+        let key = StorageKey::EventHubMessage(id);
+        env.storage().persistent().set(&key, &message);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.events().publish(
+            (symbol_short!("evthub"), symbol_short!("publish"), publisher),
+            message.clone(),
+        );
+        message
+    }
+
+    pub fn get_hub_event(env: Env, event_id: u64) -> Option<EventHubMessage> {
+        env.storage()
+            .persistent()
+            .get::<_, EventHubMessage>(&StorageKey::EventHubMessage(event_id))
     }
 
     // -----------------------------------------------------------------------
@@ -2055,6 +2276,129 @@ impl AnchorKitContract {
     // Internal helpers
     // -----------------------------------------------------------------------
 
+    fn current_yield_farm_state(env: &Env) -> YieldFarmState {
+        env.storage()
+            .persistent()
+            .get::<_, YieldFarmState>(&StorageKey::YieldFarmState)
+            .unwrap_or_else(|| {
+                let now = env.ledger().timestamp();
+                YieldFarmState {
+                    total_staked: 0,
+                    reward_rate: 0,
+                    last_update_time: now,
+                    reward_per_token_stored: 0,
+                    period_finish: now,
+                }
+            })
+    }
+
+    fn updated_yield_farm_state(env: &Env, mut state: YieldFarmState) -> YieldFarmState {
+        let now = env.ledger().timestamp();
+        let applicable_time = if now < state.period_finish {
+            now
+        } else {
+            state.period_finish
+        };
+        if applicable_time <= state.last_update_time {
+            return state;
+        }
+
+        let elapsed = applicable_time - state.last_update_time;
+        state.last_update_time = applicable_time;
+
+        if state.total_staked == 0 || state.reward_rate == 0 {
+            return state;
+        }
+
+        let reward = (elapsed as u128)
+            .checked_mul(state.reward_rate)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        let scaled_reward = reward
+            .checked_mul(REWARD_SCALE)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        let increment = scaled_reward
+            .checked_div(state.total_staked)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        state.reward_per_token_stored = state
+            .reward_per_token_stored
+            .checked_add(increment)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        state
+    }
+
+    fn current_farmer_position(env: &Env, farmer: &Address) -> FarmerPosition {
+        env.storage()
+            .persistent()
+            .get::<_, FarmerPosition>(&StorageKey::FarmerPosition(farmer.clone()))
+            .unwrap_or(FarmerPosition {
+                staked: 0,
+                reward_per_token_paid: 0,
+                pending_rewards: 0,
+            })
+    }
+
+    fn updated_farmer_position(
+        env: &Env,
+        mut position: FarmerPosition,
+        state: &YieldFarmState,
+    ) -> FarmerPosition {
+        if state.reward_per_token_stored <= position.reward_per_token_paid {
+            position.reward_per_token_paid = state.reward_per_token_stored;
+            return position;
+        }
+
+        let delta = state.reward_per_token_stored - position.reward_per_token_paid;
+        let earned = position
+            .staked
+            .checked_mul(delta)
+            .and_then(|value| value.checked_div(REWARD_SCALE))
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        position.pending_rewards = position
+            .pending_rewards
+            .checked_add(earned)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        position.reward_per_token_paid = state.reward_per_token_stored;
+        position
+    }
+
+    fn store_yield_farm_state(env: &Env, state: &YieldFarmState) {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::YieldFarmState, state);
+        env.storage()
+            .persistent()
+            .extend_ttl(&StorageKey::YieldFarmState, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    fn store_farmer_position(env: &Env, farmer: &Address, position: &FarmerPosition) {
+        let key = StorageKey::FarmerPosition(farmer.clone());
+        env.storage().persistent().set(&key, position);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    fn require_event_hub_publisher(env: &Env, publisher: &Address) {
+        let allowed = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&StorageKey::EventHubPublisher(publisher.clone()))
+            .unwrap_or(false);
+        if !allowed {
+            panic_with_error!(env, ErrorCode::UnauthorizedAttestor);
+        }
+    }
+
+    fn next_event_hub_id(env: &Env) -> u64 {
+        let inst = env.storage().instance();
+        let key = key_event_hub_counter(env);
+        let id: u64 = inst.get(&key).unwrap_or(0);
+        let next = id
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ValidationError));
+        inst.set(&key, &next);
+        inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+        id
+    }
+
     fn require_admin(env: &Env) {
         let admin: Address = env
             .storage()
@@ -2086,7 +2430,7 @@ impl AnchorKitContract {
             .get(&key_replay_window(env))
             .unwrap_or(300u64);
         let lower = now.saturating_sub(window);
-on this r        if timestamp < lower || timestamp > now {
+        if timestamp < lower || timestamp > now {
             panic_with_error!(env, ErrorCode::InvalidTimestamp);
         }
     }
@@ -2212,11 +2556,9 @@ fn verify_attestation_signature(
         }
         // Convert the key to BytesN<32>.
         let pk_n: BytesN<32> = key.clone().try_into().unwrap();
-        // Use the host environment's crypto verification.
-        if env.crypto().ed25519_verify(&pk_n, payload_hash, &sig_n) {
-            // Successful verification; exit the function.
-            return;
-        }
+        // `ed25519_verify` traps on invalid signatures and returns on success.
+        env.crypto().ed25519_verify(&pk_n, payload_hash, &sig_n);
+        return;
     }
 
     // If we reach this point, no key verified the signature.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,6 +99,10 @@ pub enum ErrorCode {
     SessionNotFound = 55,
     SessionExpired = 56,
     MissingSigningKey = 57,
+    NotInitialized = 58,
+    InvalidStrategy = 59,
+    AttestationLimitReached = 60,
+    UnauthorizedProposeAdmin = 61,
 }
 
 impl ErrorCode {
@@ -134,6 +138,9 @@ impl ErrorCode {
             ErrorCode::SessionNotFound => "Session not found",
             ErrorCode::SessionExpired => "Session has expired",
             ErrorCode::MissingSigningKey => "Anchor TOML does not publish a signing key",
+            ErrorCode::InvalidStrategy => "Routing strategy is invalid",
+            ErrorCode::AttestationLimitReached => "Attestation limit reached",
+            ErrorCode::UnauthorizedProposeAdmin => "Admin transfer proposal is not authorized",
         }
     }
 
@@ -223,6 +230,11 @@ impl AnchorKitError {
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
     pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
+    pub fn audit_log_max_size_invalid() -> Self { Self::from_code(ErrorCode::AuditLogMaxSizeInvalid) }
+    pub fn unauthorized_propose_admin() -> Self { Self::from_code(ErrorCode::UnauthorizedProposeAdmin) }
+    pub fn no_pending_admin() -> Self { Self::from_code(ErrorCode::NoPendingAdmin) }
+    pub fn not_pending_admin() -> Self { Self::from_code(ErrorCode::NotPendingAdmin) }
+    pub fn path_traversal_detected() -> Self { Self::from_code(ErrorCode::InvalidEndpointFormat) }
 
     pub fn validation_error(context: &str) -> Self {
         Self::with_context(ErrorCode::ValidationError, ErrorCode::ValidationError.default_message(), context)
@@ -243,8 +255,14 @@ impl core::fmt::Display for AnchorKitError {
 // no-std / WASM implementation — zero heap allocation
 // ---------------------------------------------------------------------------
 
-    pub fn cache_not_found() -> Self {
-        Self::from_code(ErrorCode::CacheNotFound)
+#[cfg(not(feature = "std"))]
+impl AnchorKitError {
+    pub fn from_code(code: ErrorCode) -> Self {
+        AnchorKitError {
+            code,
+            message: code.default_message(),
+            context: None,
+        }
     }
 
     pub fn already_initialized() -> Self { Self::from_code(ErrorCode::AlreadyInitialized) }
@@ -269,6 +287,11 @@ impl core::fmt::Display for AnchorKitError {
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
     pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
+    pub fn audit_log_max_size_invalid() -> Self { Self::from_code(ErrorCode::AuditLogMaxSizeInvalid) }
+    pub fn unauthorized_propose_admin() -> Self { Self::from_code(ErrorCode::UnauthorizedProposeAdmin) }
+    pub fn no_pending_admin() -> Self { Self::from_code(ErrorCode::NoPendingAdmin) }
+    pub fn not_pending_admin() -> Self { Self::from_code(ErrorCode::NotPendingAdmin) }
+    pub fn path_traversal_detected() -> Self { Self::from_code(ErrorCode::InvalidEndpointFormat) }
     pub fn validation_error(_context: &str) -> Self { Self::from_code(ErrorCode::ValidationError) }
 }
 
@@ -420,4 +443,3 @@ let codes = [
         assert_eq!(formatted, "[E15] Schema mismatch (field: transaction_id)");
     }
 }
-

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -80,15 +80,12 @@ impl RetryConfig {
 /// next request.
 pub fn is_retryable(code: u32) -> bool {
     use crate::errors::ErrorCode;
-    match code {
-        ErrorCode::ServicesNotConfigured as u32
-            | ErrorCode::AttestationNotFound as u32
-            | ErrorCode::StaleQuote as u32
-            | ErrorCode::NoQuotesAvailable as u32
-            | ErrorCode::CacheExpired as u32
-            | ErrorCode::CacheNotFound as u32 => true,
-        _ => false,
-    }
+    code == ErrorCode::ServicesNotConfigured as u32
+        || code == ErrorCode::AttestationNotFound as u32
+        || code == ErrorCode::StaleQuote as u32
+        || code == ErrorCode::NoQuotesAvailable as u32
+        || code == ErrorCode::CacheExpired as u32
+        || code == ErrorCode::CacheNotFound as u32
 }
 
 /// Execute `f` with exponential backoff retry.
@@ -132,6 +129,7 @@ where
 #[cfg(test)]
 mod retry_tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[derive(Debug, PartialEq)]
     enum TestError {

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 
 use crate::errors::{Error, ErrorCode};
@@ -304,14 +305,12 @@ pub fn initiate_deposit(raw: RawDepositResponse, asset_code: &str) -> Result<Dep
 
     Ok(DepositResponse {
         transaction_id: raw.transaction_id,
-        how: Some(raw.how),
+        how: raw.how,
         extra_info: raw.extra_info,
-        deposit_address: None,
         min_amount: raw.min_amount,
         max_amount: raw.max_amount,
         fee_fixed: raw.fee_fixed,
         fee_percent: raw.fee_percent,
-        expires_at: None,
         status: raw
             .status
             .as_deref()
@@ -340,7 +339,7 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse, asset_code: &str) -> Resu
 
     Ok(WithdrawalResponse {
         transaction_id: raw.transaction_id,
-        account_id: Some(raw.account_id),
+        account_id: raw.account_id,
         dest_account_id: raw.dest_account_id,
         memo: raw.memo,
         memo_type: raw.memo_type,
@@ -348,7 +347,6 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse, asset_code: &str) -> Resu
         max_amount: raw.max_amount,
         fee_fixed: raw.fee_fixed,
         fee_percent: raw.fee_percent,
-        estimated_completion: None,
         status: raw
             .status
             .as_deref()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -61,6 +61,14 @@ pub enum StorageKey {
     RateLimitState(Address),
     /// Per-attestor rate-limit configuration override (persistent).
     RateLimitOverride(Address),
+    /// Singleton yield farm reward accumulator state (persistent).
+    YieldFarmState,
+    /// Per-farmer yield farm stake and reward checkpoint (persistent).
+    FarmerPosition(Address),
+    /// Whether an address is allowed to publish through the Event Hub (persistent).
+    EventHubPublisher(Address),
+    /// Event Hub message by ID (persistent).
+    EventHubMessage(u64),
     // --- Instance-storage counters (stored as Vec<Symbol> keys) ---
     // These are kept as plain symbol_short! vecs because instance storage
     // requires a Vec<Symbol> key; they are defined as named constants below.
@@ -96,4 +104,7 @@ pub fn key_health_threshold(env: &Env) -> Vec<Symbol> {
 }
 pub fn key_replay_window(env: &Env) -> Vec<Symbol> {
     soroban_sdk::vec![env, symbol_short!("RPWINDOW")]
+}
+pub fn key_event_hub_counter(env: &Env) -> Vec<Symbol> {
+    soroban_sdk::vec![env, symbol_short!("EVTHUBCNT")]
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -391,3 +391,43 @@ pub struct HealthStatus {
     pub failure_count: u32,
     pub availability_percent: u32,
 }
+
+// ---------------------------------------------------------------------------
+// Yield farming and Event Hub types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub struct YieldFarmState {
+    pub total_staked: u128,
+    pub reward_rate: u128,
+    pub last_update_time: u64,
+    pub reward_per_token_stored: u128,
+    pub period_finish: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct FarmerPosition {
+    pub staked: u128,
+    pub reward_per_token_paid: u128,
+    pub pending_rewards: u128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RewardClaim {
+    pub farmer: Address,
+    pub amount: u128,
+    pub claimed_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct EventHubMessage {
+    pub event_id: u64,
+    pub publisher: Address,
+    pub topic: String,
+    pub data: Bytes,
+    pub published_at: u64,
+}

--- a/tests/yield_farming_event_hub_tests.rs
+++ b/tests/yield_farming_event_hub_tests.rs
@@ -1,0 +1,107 @@
+use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Bytes, Env, String,
+};
+
+fn set_ledger(env: &Env, timestamp: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp,
+        protocol_version: 21,
+        sequence_number: 0,
+        network_id: Default::default(),
+        base_reserve: 0,
+        min_persistent_entry_ttl: 4096,
+        min_temp_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    });
+}
+
+fn setup(timestamp: u64) -> (Env, AnchorKitContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger(&env, timestamp);
+    let admin = Address::generate(&env);
+    let client =
+        AnchorKitContractClient::new(&env, &env.register_contract(None, AnchorKitContract));
+    client.initialize(&admin, &100_u64, &None);
+    (env, client, admin)
+}
+
+#[test]
+fn zero_stake_reward_gap_is_not_paid_to_late_staker() {
+    let (env, client, _admin) = setup(1_000);
+    let farmer = Address::generate(&env);
+
+    client.configure_yield_farm(&10_u128, &1_100_u64);
+    set_ledger(&env, 1_050);
+    client.stake_yield_farm(&farmer, &100_u128);
+
+    set_ledger(&env, 1_060);
+    let claim = client.claim_yield_rewards(&farmer);
+
+    assert_eq!(claim.amount, 100_u128);
+}
+
+#[test]
+fn rewards_stop_at_period_finish() {
+    let (env, client, _admin) = setup(2_000);
+    let farmer = Address::generate(&env);
+
+    client.configure_yield_farm(&10_u128, &2_010_u64);
+    client.stake_yield_farm(&farmer, &100_u128);
+
+    set_ledger(&env, 2_020);
+    let claim = client.claim_yield_rewards(&farmer);
+
+    assert_eq!(claim.amount, 100_u128);
+}
+
+#[test]
+fn withdrawing_more_than_staked_is_rejected() {
+    let (env, client, _admin) = setup(3_000);
+    let farmer = Address::generate(&env);
+
+    client.configure_yield_farm(&1_u128, &3_100_u64);
+    client.stake_yield_farm(&farmer, &25_u128);
+    assert!(client.try_withdraw_yield_farm(&farmer, &26_u128).is_err());
+}
+
+#[test]
+fn yield_farm_requires_future_period_finish() {
+    let (_env, client, _admin) = setup(3_500);
+
+    assert!(client
+        .try_configure_yield_farm(&1_u128, &3_500_u64)
+        .is_err());
+}
+
+#[test]
+fn allowed_event_hub_publisher_can_publish_and_retrieve() {
+    let (env, client, _admin) = setup(4_000);
+    let publisher = Address::generate(&env);
+    let topic = String::from_str(&env, "attestation");
+    let data = Bytes::from_slice(&env, b"ready");
+
+    client.set_event_hub_publisher(&publisher, &true);
+    let message = client.publish_hub_event(&publisher, &topic, &data);
+    let stored = client.get_hub_event(&message.event_id).unwrap();
+
+    assert_eq!(message.event_id, 0);
+    assert_eq!(stored.publisher, publisher);
+    assert_eq!(stored.topic, topic);
+    assert_eq!(stored.data, data);
+}
+
+#[test]
+fn event_hub_rejects_unapproved_publisher() {
+    let (env, client, _admin) = setup(5_000);
+    let publisher = Address::generate(&env);
+
+    let result = client.try_publish_hub_event(
+        &publisher,
+        &String::from_str(&env, "attestation"),
+        &Bytes::from_slice(&env, b"blocked"),
+    );
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #391 
Closes #399 

# PR Description

This PR fixes #399 by adding constant-time yield farming reward accounting for edge cases around staking, claiming, and reward periods. Rewards now accrue through a reward-per-token accumulator, skip zero-stake reward gaps, stop at the configured period finish, require future reward schedules, reject invalid stake/withdraw amounts, and use checked arithmetic to avoid unsafe overflow behavior.

This PR fixes #391 by adding Event Hub publisher access control. Admins can allow or revoke publishers, and publishing now requires both allowlist membership and `publisher.require_auth()` before a hub event is stored or emitted. This keeps Event Hub publishing restricted to approved authenticated addresses.

# Changed

- #399 Added yield farm state, farmer position, reward claim types, and persistent storage keys.
- #399 Added configure, stake, withdraw, claim, and read flows with O(1) reward accounting.
- #399 Added tests for zero-stake reward gaps, period-finish caps, future schedule validation, and over-withdraw rejection.
- #391 Added Event Hub publisher allowlist state and persisted hub messages.
- #391 Added admin-managed publisher access and authenticated publish/read flows.
- #391 Added tests for approved and unapproved Event Hub publishers.