### PR TITLE
feat: add error codes and ServiceType::ExchangeQuotes variant

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,7 +21,7 @@ pub use crate::types::{
     AnchorMetadata, AnchorServices, AssetInfo, Attestation, AuditLog, CapabilitiesCache,
     CachedToml, FiatCurrency, HealthStatus, MetadataCache, OperationContext, Quote, RequestId,
     RoutingOptions, RoutingRequest, Session, StellarToml, TracingSpan,
-    SERVICE_DEPOSITS, SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_KYC, ServiceType,
+    SERVICE_DEPOSITS, SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_KYC, SERVICE_EXCHANGE_QUOTES, ServiceType,
 };
 
 const MIN_TEMP_TTL: u32 = 15; // min_temp_entry_ttl - 1
@@ -500,11 +500,12 @@ impl AnchorKitContract {
         }
         let mut seen = Vec::new(&env);
         for s in services.iter() {
-            // Reject any value that is not one of the four known service constants.
+            // Reject any value that is not one of the known service constants.
             if s != SERVICE_DEPOSITS
                 && s != SERVICE_WITHDRAWALS
                 && s != SERVICE_QUOTES
                 && s != SERVICE_KYC
+                && s != SERVICE_EXCHANGE_QUOTES
             {
                 panic_with_error!(&env, ErrorCode::InvalidServiceType);
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,6 +99,9 @@ pub enum ErrorCode {
     SessionNotFound = 55,
     SessionExpired = 56,
     MissingSigningKey = 57,
+    AttestationExpired = 121,
+    ContractPaused = 122,
+    AdminTransferPending = 123,
 }
 
 impl ErrorCode {
@@ -134,6 +137,9 @@ impl ErrorCode {
             ErrorCode::SessionNotFound => "Session not found",
             ErrorCode::SessionExpired => "Session has expired",
             ErrorCode::MissingSigningKey => "Anchor TOML does not publish a signing key",
+            ErrorCode::AttestationExpired => "Attestation has expired",
+            ErrorCode::ContractPaused => "Contract is paused",
+            ErrorCode::AdminTransferPending => "Admin transfer is already pending",
         }
     }
 
@@ -223,6 +229,9 @@ impl AnchorKitError {
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
     pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
+    pub fn attestation_expired() -> Self { Self::from_code(ErrorCode::AttestationExpired) }
+    pub fn contract_paused() -> Self { Self::from_code(ErrorCode::ContractPaused) }
+    pub fn admin_transfer_pending() -> Self { Self::from_code(ErrorCode::AdminTransferPending) }
 
     pub fn validation_error(context: &str) -> Self {
         Self::with_context(ErrorCode::ValidationError, ErrorCode::ValidationError.default_message(), context)
@@ -269,6 +278,9 @@ impl core::fmt::Display for AnchorKitError {
     pub fn cache_expired() -> Self { Self::from_code(ErrorCode::CacheExpired) }
     pub fn cache_not_found() -> Self { Self::from_code(ErrorCode::CacheNotFound) }
     pub fn missing_signing_key() -> Self { Self::from_code(ErrorCode::MissingSigningKey) }
+    pub fn attestation_expired() -> Self { Self::from_code(ErrorCode::AttestationExpired) }
+    pub fn contract_paused() -> Self { Self::from_code(ErrorCode::ContractPaused) }
+    pub fn admin_transfer_pending() -> Self { Self::from_code(ErrorCode::AdminTransferPending) }
     pub fn validation_error(_context: &str) -> Self { Self::from_code(ErrorCode::ValidationError) }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,6 +116,7 @@ pub const SERVICE_DEPOSITS: u32 = 1;
 pub const SERVICE_WITHDRAWALS: u32 = 2;
 pub const SERVICE_QUOTES: u32 = 3;
 pub const SERVICE_KYC: u32 = 4;
+pub const SERVICE_EXCHANGE_QUOTES: u32 = 5;
 
 /// Typed representation of a service capability an anchor can support.
 ///
@@ -127,6 +128,7 @@ pub enum ServiceType {
     Withdrawals,
     Quotes,
     KYC,
+    ExchangeQuotes,
 }
 
 impl ServiceType {
@@ -136,6 +138,7 @@ impl ServiceType {
             ServiceType::Withdrawals => SERVICE_WITHDRAWALS,
             ServiceType::Quotes => SERVICE_QUOTES,
             ServiceType::KYC => SERVICE_KYC,
+            ServiceType::ExchangeQuotes => SERVICE_EXCHANGE_QUOTES,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements four enhancements to the AnchorKit error handling system and service type support:

### Changes Implemented

#### Error Code Additions
- **Issue #639**: Add error code 121 for `AttestationExpired` - thrown when accessing an expired attestation
- **Issue #640**: Add error code 122 for `ContractPaused` - thrown when the contract is paused
- **Issue #641**: Add error code 123 for `AdminTransferPending` - thrown when attempting a second admin transfer before the first is accepted

#### Service Type Enhancement
- **Issue #642**: Add `ServiceType::ExchangeQuotes` variant for anchors that provide foreign exchange rates without executing trades

### Detailed Changes

#### src/errors.rs
- Added three new `ErrorCode` enum variants with stable codes: 121, 122, and 123
- Added corresponding default messages for each error:
  - `AttestationExpired`: "Attestation has expired"
  - `ContractPaused`: "Contract is paused"
  - `AdminTransferPending`: "Admin transfer is already pending"
- Added constructor methods for all three errors in both std and no-std (WASM) implementations:
  - `AnchorKitError::attestation_expired()`
  - `AnchorKitError::contract_paused()`
  - `AnchorKitError::admin_transfer_pending()`

#### src/types.rs
- Added `SERVICE_EXCHANGE_QUOTES` constant with value 5
- Added `ExchangeQuotes` variant to the `ServiceType` enum
- Updated `ServiceType::as_u32()` method to handle the new `ExchangeQuotes` variant

#### src/contract.rs
- Updated imports to include `SERVICE_EXCHANGE_QUOTES`
- Modified `configure_services()` validation logic to accept the new `SERVICE_EXCHANGE_QUOTES` service type
- Updated comment to reflect support for five service types instead of four

### Testing
All changes follow existing code patterns and maintain consistency with:
- Both std and no-std (WASM) builds
- Soroban contract compatibility
- Existing error handling infrastructure

The implementation includes proper default messages and constructor methods for easy error creation and handling throughout the codebase.

### Closes
- Closes #639
- Closes #640
- Closes #641
- Closes #642