### PR TITLE
ci: add Rust CI workflow with build, test, and clippy

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,42 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/rust-ci.yml` that runs on every push to `main` and every pull request
- Runs `cargo build`, `cargo test`, and `cargo clippy -- -D warnings`
- Includes cargo registry caching to speed up subsequent runs

## Test plan
- [ ] Push a commit to main or open a PR and verify the `Rust CI` workflow triggers
- [ ] Introduce a clippy warning and confirm the workflow fails
- [ ] Fix the warning and confirm the workflow passes

Closes #721