### PR TITLE
feat: add dependabot config for Rust and npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      soroban:
+        patterns:
+          - "soroban-*"
+      crypto:
+        patterns:
+          - "sha2"
+          - "ed25519-dalek"
+          - "hex"
+      serde:
+        patterns:
+          - "serde"
+          - "serde_json"
+
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react*"
+      testing:
+        patterns:
+          - "jest*"
+          - "@testing-library/*"
+          - "@types/jest"
+      build-tools:
+        patterns:
+          - "typescript"
+          - "ts-*"
+          - "@typescript-eslint/*"
+          - "eslint*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly update schedules for both Cargo and npm (`ui/`) ecosystems
- Groups related packages (soroban, crypto, serde for Rust; react, testing, build-tools for npm) to reduce PR noise

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML and passes GitHub's dependabot schema validation
- [ ] Verify that weekly PRs are created in the expected groups after the schedule triggers

Closes #725