### PR TITLE
feat: add cargo-fuzz targets for deterministic_hash and domain_validator

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "anchorkit-fuzz"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+soroban-sdk = { version = "21.7.0", features = ["testutils"] }
+
+[dependencies.anchorkit]
+path = ".."
+features = ["std"]
+
+[[bin]]
+name = "fuzz_deterministic_hash"
+path = "fuzz_targets/fuzz_deterministic_hash.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_domain_validator"
+path = "fuzz_targets/fuzz_domain_validator.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_deterministic_hash.rs
+++ b/fuzz/fuzz_targets/fuzz_deterministic_hash.rs
@@ -1,0 +1,28 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Bytes, Env};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 8 {
+        return;
+    }
+
+    let env = Env::default();
+
+    let timestamp = u64::from_be_bytes(data[..8].try_into().unwrap());
+    let payload = &data[8..];
+
+    let subject = soroban_sdk::Address::generate(&env);
+    let bytes = Bytes::from_slice(&env, payload);
+
+    // Must not panic regardless of input
+    let hash = anchorkit::deterministic_hash::compute_payload_hash(&env, &subject, timestamp, &bytes);
+
+    // Determinism: same inputs must always produce the same hash
+    let hash2 = anchorkit::deterministic_hash::compute_payload_hash(&env, &subject, timestamp, &bytes);
+    assert_eq!(hash, hash2, "hash is non-deterministic");
+
+    // verify_payload_hash must agree with itself
+    assert!(anchorkit::deterministic_hash::verify_payload_hash(&hash, &hash));
+});

--- a/fuzz/fuzz_targets/fuzz_domain_validator.rs
+++ b/fuzz/fuzz_targets/fuzz_domain_validator.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // Must not panic regardless of input
+    let _ = anchorkit::domain_validator::validate_anchor_domain(s);
+
+    // Batch variant must also be panic-free and return one result per input
+    let inputs: Vec<&str> = s.lines().collect();
+    let results = anchorkit::domain_validator::validate_anchor_domain_batch(&inputs);
+    assert_eq!(results.len(), inputs.len());
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 extern crate alloc;
 
-mod deterministic_hash;
-mod domain_validator;
+pub mod deterministic_hash;
+pub mod domain_validator;
 mod errors;
 mod events;
 mod storage;


### PR DESCRIPTION
## Summary

- Adds `fuzz/Cargo.toml` wiring up `cargo-fuzz` for the crate
- Adds `fuzz/fuzz_targets/fuzz_deterministic_hash.rs`: exercises `compute_payload_hash` with arbitrary timestamps and payloads, asserting no panics and full determinism
- Adds `fuzz/fuzz_targets/fuzz_domain_validator.rs`: feeds arbitrary UTF-8 strings and multi-line batches into `validate_anchor_domain` and `validate_anchor_domain_batch`, asserting no panics and correct result count
- Makes `deterministic_hash` and `domain_validator` modules `pub` so the fuzz crate can reference them

## Test plan

- [ ] `cargo fuzz run fuzz_deterministic_hash -- -max_total_time=60` runs without panics
- [ ] `cargo fuzz run fuzz_domain_validator -- -max_total_time=60` runs without panics

Closes #726