### PR TITLE
ci: add WASM build size check step to CI pipeline

### DIFF
--- a/.github/workflows/wasm-size-check.yml
+++ b/.github/workflows/wasm-size-check.yml
@@ -1,0 +1,53 @@
+name: WASM Size Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Maximum allowed WASM binary size in bytes (100 KB)
+  WASM_SIZE_LIMIT: 102400
+
+jobs:
+  wasm-size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
+
+      - name: Build WASM (release)
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Check WASM binary size
+        run: |
+          WASM_FILE="target/wasm32-unknown-unknown/release/anchorkit.wasm"
+          WASM_SIZE=$(wc -c < "$WASM_FILE")
+          echo "WASM binary size: $WASM_SIZE bytes"
+          echo "Size limit:       $WASM_SIZE_LIMIT bytes"
+          if [ "$WASM_SIZE" -gt "$WASM_SIZE_LIMIT" ]; then
+            echo "ERROR: WASM binary exceeds the configured size limit."
+            echo "  Actual:  $WASM_SIZE bytes"
+            echo "  Limit:   $WASM_SIZE_LIMIT bytes"
+            echo "  Excess:  $(( WASM_SIZE - WASM_SIZE_LIMIT )) bytes"
+            exit 1
+          fi
+          echo "WASM size check passed."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/wasm-size-check.yml` that builds the WASM binary and enforces a size budget
- Default limit is **100 KB** (102400 bytes), configurable via the `WASM_SIZE_LIMIT` env variable in the workflow
- Reports actual size, limit, and excess bytes on failure for easy debugging
- Targets `wasm32-unknown-unknown` using the `release` profile (already optimised with `opt-level = "z"`)

## Test plan
- [ ] Open a PR and verify the `WASM Size Check` workflow triggers
- [ ] Temporarily lower `WASM_SIZE_LIMIT` below the actual binary size and confirm the job fails with a clear error message
- [ ] Restore the limit and confirm the job passes

Closes #723