### PR TITLE
ci: add code coverage reporting with cargo-tarpaulin and Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,44 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
+
+      - name: Generate coverage report
+        run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: cobertura.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/coverage.yml` that generates a coverage report on every push to `main` and every PR
- Uses `cargo-tarpaulin` with `--all-features --workspace` to measure coverage across the full codebase
- Uploads the Cobertura XML report to Codecov via `codecov/codecov-action@v4`
- Requires a `CODECOV_TOKEN` repository secret to be set for authenticated uploads

## Test plan
- [ ] Add `CODECOV_TOKEN` to repository secrets (Settings → Secrets and variables → Actions)
- [ ] Open a PR and verify the `Code Coverage` workflow triggers and uploads a report to Codecov
- [ ] Check the Codecov dashboard to confirm coverage trends are visible

Closes #724