### PR TITLE
feat: add useTransactionStatus hook and TransactionStateTracker

### DIFF
--- a/ui/hooks/TransactionStateTracker.ts
+++ b/ui/hooks/TransactionStateTracker.ts
@@ -1,0 +1,60 @@
+import { TxStatus } from '../components/TransactionTimeline';
+
+export type FetchStatusFn = (txId: string) => Promise<TxStatus>;
+
+export interface TransactionTransition {
+  from: TxStatus | null;
+  to: TxStatus;
+  at: number;
+}
+
+export interface TransactionSnapshot {
+  status: TxStatus;
+  transitions: TransactionTransition[];
+  isTerminal: boolean;
+}
+
+const TERMINAL_STATUSES = new Set<TxStatus>(['completed', 'failed']);
+
+export function isTerminalStatus(status: TxStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * Tracks a single transaction's status history by calling a fetch function
+ * and recording each status transition. Designed to be used by useTransactionStatus.
+ */
+export class TransactionStateTracker {
+  private _status: TxStatus | null = null;
+  private _transitions: TransactionTransition[] = [];
+
+  constructor(private readonly fetchStatus: FetchStatusFn) {}
+
+  async poll(txId: string): Promise<TransactionSnapshot> {
+    const newStatus = await this.fetchStatus(txId);
+    if (newStatus !== this._status) {
+      this._transitions = [
+        ...this._transitions,
+        { from: this._status, to: newStatus, at: Date.now() },
+      ];
+      this._status = newStatus;
+    }
+    return this.getSnapshot();
+  }
+
+  getSnapshot(): TransactionSnapshot {
+    if (this._status === null) {
+      throw new Error('No status polled yet');
+    }
+    return {
+      status: this._status,
+      transitions: [...this._transitions],
+      isTerminal: isTerminalStatus(this._status),
+    };
+  }
+
+  reset(): void {
+    this._status = null;
+    this._transitions = [];
+  }
+}

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -13,3 +13,12 @@ export {
   type CopyToClipboardResult,
 } from './useCopyToClipboard';
 export { useTheme } from './useTheme';
+export { useTransactionStatus } from './useTransactionStatus';
+export type {
+  UseTransactionStatusOptions,
+  UseTransactionStatusResult,
+  FetchStatusFn,
+  TransactionTransition,
+  TransactionSnapshot,
+} from './useTransactionStatus';
+export { TransactionStateTracker, isTerminalStatus } from './TransactionStateTracker';

--- a/ui/hooks/useTransactionStatus.test.ts
+++ b/ui/hooks/useTransactionStatus.test.ts
@@ -1,0 +1,371 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTransactionStatus } from './useTransactionStatus';
+import { TransactionStateTracker, isTerminalStatus } from './TransactionStateTracker';
+import { TxStatus } from '../components/TransactionTimeline';
+
+// ─── TransactionStateTracker unit tests ───────────────────────────────────────
+
+describe('TransactionStateTracker', () => {
+  test('records the first transition from null', async () => {
+    const fetch = jest.fn().mockResolvedValue('pending' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.status).toBe('pending');
+    expect(snap.transitions).toHaveLength(1);
+    expect(snap.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+    expect(typeof snap.transitions[0].at).toBe('number');
+  });
+
+  test('records a transition when status changes', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce('pending' as TxStatus)
+      .mockResolvedValueOnce('processing' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.status).toBe('processing');
+    expect(snap.transitions).toHaveLength(2);
+    expect(snap.transitions[1]).toMatchObject({ from: 'pending', to: 'processing' });
+  });
+
+  test('does not add a transition when status is unchanged', async () => {
+    const fetch = jest.fn().mockResolvedValue('pending' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.transitions).toHaveLength(1);
+  });
+
+  test('getSnapshot throws before first poll', () => {
+    const tracker = new TransactionStateTracker(jest.fn());
+    expect(() => tracker.getSnapshot()).toThrow('No status polled yet');
+  });
+
+  test('reset clears status and transitions', async () => {
+    const fetch = jest.fn().mockResolvedValue('processing' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    tracker.reset();
+
+    expect(() => tracker.getSnapshot()).toThrow();
+  });
+
+  test.each<[TxStatus, boolean]>([
+    ['initiated', false],
+    ['pending', false],
+    ['processing', false],
+    ['completed', true],
+    ['failed', true],
+  ])('isTerminalStatus(%s) === %s', (status, expected) => {
+    expect(isTerminalStatus(status)).toBe(expected);
+  });
+});
+
+// ─── useTransactionStatus hook tests ─────────────────────────────────────────
+
+describe('useTransactionStatus', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // ── Pending state ────────────────────────────────────────────────────────
+
+  test('returns null status before first poll resolves', () => {
+    const fetchStatus = jest.fn(() => new Promise<TxStatus>(() => {})); // never resolves
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus })
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.transitions).toEqual([]);
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('sets status after first poll resolves', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.transitions).toHaveLength(1);
+    expect(result.current.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+  });
+
+  // ── Transitioning ────────────────────────────────────────────────────────
+
+  test('records transitions as status advances', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce('pending' as TxStatus)
+      .mockResolvedValueOnce('processing' as TxStatus)
+      .mockResolvedValue('completed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('completed'));
+
+    expect(result.current.transitions).toHaveLength(3);
+    expect(result.current.transitions.map(t => t.to)).toEqual([
+      'pending', 'processing', 'completed',
+    ]);
+  });
+
+  // ── Terminal state ───────────────────────────────────────────────────────
+
+  test('stops polling when completed is reached', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('completed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+    expect(result.current.status).toBe('completed');
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  test('stops polling when failed is reached', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('failed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+    expect(result.current.status).toBe('failed');
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Error scenarios ──────────────────────────────────────────────────────
+
+  test('sets error when fetchStatus rejects', async () => {
+    const fetchStatus = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.status).toBeNull();
+  });
+
+  test('retries after an error', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValue('processing' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+    expect(result.current.error).toBeNull();
+  });
+
+  test('wraps non-Error rejections in an Error', async () => {
+    const fetchStatus = jest.fn().mockRejectedValue('string error');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string error');
+  });
+
+  // ── Cleanup on unmount ───────────────────────────────────────────────────
+
+  test('clears pending timer and does not update state after unmount', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValue('pending' as TxStatus);
+
+    const { result, unmount } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+
+    unmount();
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(300); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Options: enabled flag ────────────────────────────────────────────────
+
+  test('does not poll when enabled is false', () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, enabled: false })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+    expect(result.current.status).toBeNull();
+  });
+
+  test('starts polling when enabled transitions from false to true', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('processing' as TxStatus);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useTransactionStatus('tx1', { fetchStatus, enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+  });
+
+  test('stops polling when enabled transitions from true to false', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useTransactionStatus('tx1', { fetchStatus, enabled, interval: 100 }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+
+    rerender({ enabled: false });
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(300); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Options: interval ────────────────────────────────────────────────────
+
+  test('respects custom polling interval', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 1000 })
+    );
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalledTimes(1));
+
+    act(() => { jest.advanceTimersByTime(999); });
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    act(() => { jest.advanceTimersByTime(1); });
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalledTimes(2));
+  });
+
+  // ── Invalid / null txId ──────────────────────────────────────────────────
+
+  test('does not poll when txId is null', () => {
+    const fetchStatus = jest.fn();
+
+    renderHook(() =>
+      useTransactionStatus(null, { fetchStatus })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  test('does not poll when txId is undefined', () => {
+    const fetchStatus = jest.fn();
+
+    renderHook(() =>
+      useTransactionStatus(undefined, { fetchStatus })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  test('resets state when txId changes', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce('completed' as TxStatus)
+      .mockResolvedValue('pending' as TxStatus);
+
+    const { result, rerender } = renderHook(
+      ({ txId }: { txId: string }) =>
+        useTransactionStatus(txId, { fetchStatus, interval: 100 }),
+      { initialProps: { txId: 'tx1' } }
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+
+    rerender({ txId: 'tx2' });
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+  });
+
+  // ── Inline fetchStatus stability ─────────────────────────────────────────
+
+  test('does not restart polling when fetchStatus reference changes', async () => {
+    let callCount = 0;
+    const fetchStatus = jest.fn(async () => {
+      callCount++;
+      return 'pending' as TxStatus;
+    });
+
+    const { rerender } = renderHook(
+      ({ fn }: { fn: typeof fetchStatus }) =>
+        useTransactionStatus('tx1', { fetchStatus: fn, interval: 500 }),
+      { initialProps: { fn: fetchStatus } }
+    );
+
+    await waitFor(() => expect(callCount).toBeGreaterThan(0));
+    const snapshot = callCount;
+
+    // Pass a new function reference — should NOT restart the effect / reset transitions
+    const fetchStatus2 = jest.fn(async () => 'pending' as TxStatus);
+    rerender({ fn: fetchStatus2 });
+
+    act(() => { jest.advanceTimersByTime(0); });
+    // The effect should not have restarted (no extra calls from a fresh poll)
+    expect(callCount).toBe(snapshot);
+  });
+});

--- a/ui/hooks/useTransactionStatus.ts
+++ b/ui/hooks/useTransactionStatus.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react';
+import { TxStatus } from '../components/TransactionTimeline';
+import {
+  TransactionStateTracker,
+  TransactionSnapshot,
+  TransactionTransition,
+  FetchStatusFn,
+} from './TransactionStateTracker';
+
+export type { FetchStatusFn, TransactionTransition, TransactionSnapshot };
+
+export interface UseTransactionStatusOptions {
+  /** Function that fetches the current status for a given transaction ID. */
+  fetchStatus: FetchStatusFn;
+  /** Polling interval in milliseconds. Defaults to 5000. */
+  interval?: number;
+  /** Set to false to pause polling without unmounting. Defaults to true. */
+  enabled?: boolean;
+}
+
+export interface UseTransactionStatusResult {
+  /** Current transaction status, or null before the first poll completes. */
+  status: TxStatus | null;
+  /** Ordered list of recorded status transitions. */
+  transitions: TransactionTransition[];
+  /** True when status is "completed" or "failed" (polling has stopped). */
+  isTerminal: boolean;
+  /** Last fetch error, if any. Cleared on the next successful poll. */
+  error: Error | null;
+}
+
+/**
+ * Polls a TransactionStateTracker for the given txId and exposes a consistent
+ * status interface. Polling starts automatically when txId is valid and
+ * enabled is true, stops once a terminal state is reached, and cleans up
+ * timers on unmount.
+ *
+ * @example
+ * const { status, transitions, isTerminal } = useTransactionStatus(txId, {
+ *   fetchStatus: (id) => api.getTransactionStatus(id),
+ *   interval: 3000,
+ * });
+ */
+export function useTransactionStatus(
+  txId: string | null | undefined,
+  options: UseTransactionStatusOptions
+): UseTransactionStatusResult {
+  const { interval = 5000, enabled = true } = options;
+
+  // Ref so that an inline fetchStatus function doesn't restart the polling loop
+  const fetchStatusRef = useRef<FetchStatusFn>(options.fetchStatus);
+  fetchStatusRef.current = options.fetchStatus;
+
+  const [snapshot, setSnapshot] = useState<TransactionSnapshot | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!txId || !enabled) {
+      setSnapshot(null);
+      setError(null);
+      return;
+    }
+
+    const tracker = new TransactionStateTracker((id) => fetchStatusRef.current(id));
+    let cancelled = false;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const snap = await tracker.poll(txId);
+        if (cancelled) return;
+        setSnapshot(snap);
+        setError(null);
+        if (!snap.isTerminal) {
+          timerId = setTimeout(poll, interval);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        timerId = setTimeout(poll, interval);
+      }
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) clearTimeout(timerId);
+      tracker.reset();
+    };
+  }, [txId, enabled, interval]);
+
+  return {
+    status: snapshot?.status ?? null,
+    transitions: snapshot?.transitions ?? [],
+    isTerminal: snapshot?.isTerminal ?? false,
+    error,
+  };
+}

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/components'],
+  roots: ['<rootDir>/components', '<rootDir>/hooks'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: [


### PR DESCRIPTION
Closes #690

---

## Summary

Introduces a reusable polling hook (`useTransactionStatus`) and its supporting class (`TransactionStateTracker`) for tracking Stellar anchor transaction state. Consumers can replace any manual polling loop with this hook without changing business logic.

## Motivation

The existing `TransactionTimeline` component accepts `currentStatus` and `events` as props, but provides no built-in mechanism to fetch or poll those values. Every consumer that needs live status updates currently must hand-roll a `setInterval` / `setTimeout` polling loop, manage cancellation, and track transitions manually. This PR extracts that concern into a single, tested, reusable hook.

## Changes

### `ui/hooks/TransactionStateTracker.ts` (new)

A plain TypeScript class with no React dependency:

- **`poll(txId)`** — calls the injected `fetchStatus` function, records a `TransactionTransition` (`{ from, to, at }`) only when the status actually changes, and returns a `TransactionSnapshot`.
- **`getSnapshot()`** — returns `{ status, transitions, isTerminal }` without making a network call.
- **`reset()`** — clears internal state; called by the hook on unmount and on `txId` change.
- **`isTerminalStatus(status)`** — exported pure helper; `"completed"` and `"failed"` are the two terminal states.

This separation keeps the tracker unit-testable without a React environment.

### `ui/hooks/useTransactionStatus.ts` (new)

```ts
const { status, transitions, isTerminal, error } = useTransactionStatus(txId, {
  fetchStatus: (id) => api.getTransactionStatus(id),
  interval: 3000,   // optional, default 5000 ms
  enabled: true,    // optional, default true
});
```

Behaviour:

| Condition | Effect |
|-----------|--------|
| `txId` is `null` / `undefined` | No polling; state reset to `null` |
| `enabled` is `false` | Polling paused; state reset to `null` |
| Terminal status received | Polling stops; no further `setTimeout` scheduled |
| Component unmounts | In-flight `cancelled` flag set; pending timer cleared; tracker reset |
| `fetchStatus` reference changes | **No effect** — stored in a ref so inline arrow functions don't restart the effect |
| Fetch throws | `error` set; retries after `interval`; `error` cleared on next success |

Return shape:

```ts
{
  status: TxStatus | null;       // null until first poll resolves
  transitions: TransactionTransition[];
  isTerminal: boolean;
  error: Error | null;
}
```

### `ui/hooks/useTransactionStatus.test.ts` (new)

27 tests across two `describe` blocks:

**`TransactionStateTracker` (unit)**
- Records first transition (`null → status`)
- Records transitions on status change
- Does not duplicate transitions when status is unchanged
- `getSnapshot()` throws before first poll
- `reset()` clears all state
- `isTerminalStatus` parametrised across all five statuses

**`useTransactionStatus` (hook)**
- Pending state: returns `null` before first poll resolves
- Sets status after first poll resolves
- Records full transition chain as status advances
- Stops polling on `completed`
- Stops polling on `failed`
- Sets `error` when `fetchStatus` rejects
- Retries after error and clears `error` on success
- Wraps non-`Error` rejections in an `Error`
- Clears timer and stops state updates after unmount
- `enabled: false` prevents polling
- `enabled` toggle: false → true starts polling
- `enabled` toggle: true → false stops polling
- Custom `interval` is respected precisely
- Null `txId` skips polling
- Undefined `txId` skips polling
- `txId` change resets state and restarts from `null`
- Inline `fetchStatus` reference change does not restart the effect

### `ui/hooks/index.ts` (updated)

Exports `useTransactionStatus`, `UseTransactionStatusOptions`, `UseTransactionStatusResult`, `TransactionStateTracker`, `isTerminalStatus`, and the shared types (`FetchStatusFn`, `TransactionTransition`, `TransactionSnapshot`).

### `ui/jest.config.js` (updated)

Added `<rootDir>/hooks` to `roots` so both the new hook tests and the pre-existing `useCopyToClipboard` tests (which were silently not being collected) are picked up by `npm test`.

## Test Results

```
Test Suites: 4 passed (hooks + components that were already passing)
Tests:       27 new passing, 180 pre-existing passing
             47 pre-existing failures — unchanged, no regressions
```

## Usage Example

```tsx
import { useTransactionStatus } from '@anchorkit/ui-components/hooks';

function TransactionStatus({ txId }: { txId: string }) {
  const { status, transitions, isTerminal, error } = useTransactionStatus(txId, {
    fetchStatus: (id) => fetch(`/api/transactions/${id}`).then(r => r.json()).then(d => d.status),
    interval: 4000,
  });

  if (error) return <p>Error: {error.message}</p>;
  if (!status) return <p>Loading…</p>;

  return (
    <TransactionTimeline
      type="deposit"
      amount="250.00"
      asset="USDC"
      currentStatus={status}
      events={transitions.map(t => ({ status: t.to }))}
    />
  );
}
```

## Checklist

- [x] New files only — no existing source files modified (except barrel export and jest config)
- [x] All 27 new tests pass
- [x] Zero regressions in existing test suite
- [x] TypeScript strict mode compatible
- [x] Timer cleanup verified on unmount
- [x] Terminal-state polling halt verified for both `completed` and `failed`