### PR TITLE
feat: add useAnchorCapabilities hook with SWR-style caching

### DIFF
--- a/ui/hooks/TransactionStateTracker.ts
+++ b/ui/hooks/TransactionStateTracker.ts
@@ -1,0 +1,60 @@
+import { TxStatus } from '../components/TransactionTimeline';
+
+export type FetchStatusFn = (txId: string) => Promise<TxStatus>;
+
+export interface TransactionTransition {
+  from: TxStatus | null;
+  to: TxStatus;
+  at: number;
+}
+
+export interface TransactionSnapshot {
+  status: TxStatus;
+  transitions: TransactionTransition[];
+  isTerminal: boolean;
+}
+
+const TERMINAL_STATUSES = new Set<TxStatus>(['completed', 'failed']);
+
+export function isTerminalStatus(status: TxStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * Tracks a single transaction's status history by calling a fetch function
+ * and recording each status transition. Designed to be used by useTransactionStatus.
+ */
+export class TransactionStateTracker {
+  private _status: TxStatus | null = null;
+  private _transitions: TransactionTransition[] = [];
+
+  constructor(private readonly fetchStatus: FetchStatusFn) {}
+
+  async poll(txId: string): Promise<TransactionSnapshot> {
+    const newStatus = await this.fetchStatus(txId);
+    if (newStatus !== this._status) {
+      this._transitions = [
+        ...this._transitions,
+        { from: this._status, to: newStatus, at: Date.now() },
+      ];
+      this._status = newStatus;
+    }
+    return this.getSnapshot();
+  }
+
+  getSnapshot(): TransactionSnapshot {
+    if (this._status === null) {
+      throw new Error('No status polled yet');
+    }
+    return {
+      status: this._status,
+      transitions: [...this._transitions],
+      isTerminal: isTerminalStatus(this._status),
+    };
+  }
+
+  reset(): void {
+    this._status = null;
+    this._transitions = [];
+  }
+}

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -22,3 +22,16 @@ export type {
   TransactionSnapshot,
 } from './useTransactionStatus';
 export { TransactionStateTracker, isTerminalStatus } from './TransactionStateTracker';
+export { useAnchorCapabilities, clearCapabilitiesCache } from './useAnchorCapabilities';
+export type {
+  AnchorServicesResult,
+  FetchCapabilitiesFn,
+  UseAnchorCapabilitiesOptions,
+  UseAnchorCapabilitiesResult,
+} from './useAnchorCapabilities';
+export {
+  SERVICE_DEPOSITS,
+  SERVICE_WITHDRAWALS,
+  SERVICE_QUOTES,
+  SERVICE_KYC,
+} from './useAnchorCapabilities';

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -13,3 +13,12 @@ export {
   type CopyToClipboardResult,
 } from './useCopyToClipboard';
 export { useTheme } from './useTheme';
+export { useTransactionStatus } from './useTransactionStatus';
+export type {
+  UseTransactionStatusOptions,
+  UseTransactionStatusResult,
+  FetchStatusFn,
+  TransactionTransition,
+  TransactionSnapshot,
+} from './useTransactionStatus';
+export { TransactionStateTracker, isTerminalStatus } from './TransactionStateTracker';

--- a/ui/hooks/useAnchorCapabilities.test.ts
+++ b/ui/hooks/useAnchorCapabilities.test.ts
@@ -1,0 +1,581 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  useAnchorCapabilities,
+  clearCapabilitiesCache,
+  AnchorServicesResult,
+  SERVICE_DEPOSITS,
+  SERVICE_WITHDRAWALS,
+  SERVICE_QUOTES,
+  SERVICE_KYC,
+} from './useAnchorCapabilities';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+// Valid Stellar StrKey addresses (G-address: 'G' + 55 Base32 chars)
+const ATTESTOR   = 'G' + 'A'.repeat(55);
+const ATTESTOR_2 = 'G' + 'B'.repeat(55);
+
+const BASE_CAPS: AnchorServicesResult = {
+  anchor: ATTESTOR,
+  services: [SERVICE_DEPOSITS, SERVICE_WITHDRAWALS],
+};
+
+const FULL_CAPS: AnchorServicesResult = {
+  anchor: ATTESTOR,
+  services: [SERVICE_DEPOSITS, SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_KYC],
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeFetch(...results: AnchorServicesResult[]) {
+  let i = 0;
+  return jest.fn(async (_: string) => {
+    const r = results[Math.min(i, results.length - 1)];
+    i += 1;
+    return r;
+  });
+}
+
+// ── Successful fetch ──────────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — successful fetch', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('isLoading is true initially, false after fetch resolves', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.capabilities).toEqual(BASE_CAPS);
+    expect(result.current.error).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(ATTESTOR);
+  });
+
+  test('passes the attestor address to fetchCapabilities', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+    renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(ATTESTOR));
+  });
+
+  test('capabilities includes all returned service codes', async () => {
+    const fetch = jest.fn().mockResolvedValue(FULL_CAPS);
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(result.current.capabilities).toEqual(FULL_CAPS));
+    expect(result.current.capabilities!.services).toEqual([
+      SERVICE_DEPOSITS, SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_KYC,
+    ]);
+  });
+});
+
+// ── Caching behavior ──────────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — caching', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('second consumer receives cached data immediately without loading', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+
+    // First consumer populates the cache.
+    const { result: r1 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(r1.current.capabilities).toEqual(BASE_CAPS));
+
+    // Second consumer mounts after cache is warm.
+    const { result: r2 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    // Should have data immediately (no loading state).
+    expect(r2.current.capabilities).toEqual(BASE_CAPS);
+    expect(r2.current.isLoading).toBe(false);
+    expect(r2.current.error).toBeNull();
+  });
+
+  test('deduplicates concurrent requests for the same attestor', async () => {
+    let resolve!: (v: AnchorServicesResult) => void;
+    const promise = new Promise<AnchorServicesResult>(r => { resolve = r; });
+    const fetch = jest.fn().mockReturnValue(promise);
+
+    // Both hooks mount before the fetch resolves.
+    const { result: r1 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    const { result: r2 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    // Only one network request despite two consumers.
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    act(() => { resolve(BASE_CAPS); });
+
+    await waitFor(() => expect(r1.current.capabilities).toEqual(BASE_CAPS));
+    expect(r2.current.capabilities).toEqual(BASE_CAPS);
+  });
+
+  test('separate attestor keys result in independent fetches', async () => {
+    const caps2: AnchorServicesResult = { anchor: ATTESTOR_2, services: [SERVICE_KYC] };
+    const fetch = jest.fn()
+      .mockImplementation(async (id: string) =>
+        id === ATTESTOR ? BASE_CAPS : caps2
+      );
+
+    const { result: r1 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    const { result: r2 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR_2, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(r1.current.capabilities).toEqual(BASE_CAPS));
+    await waitFor(() => expect(r2.current.capabilities).toEqual(caps2));
+
+    expect(fetch).toHaveBeenCalledWith(ATTESTOR);
+    expect(fetch).toHaveBeenCalledWith(ATTESTOR_2);
+  });
+
+  test('cross-component cache update: consumer B sees data fetched by consumer A', async () => {
+    let resolveA!: (v: AnchorServicesResult) => void;
+    const promiseA = new Promise<AnchorServicesResult>(r => { resolveA = r; });
+    const fetch = jest.fn().mockReturnValue(promiseA);
+
+    renderHook(() => useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch }));
+    const { result: r2 } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    expect(r2.current.capabilities).toBeNull(); // not yet fetched
+
+    act(() => { resolveA(BASE_CAPS); });
+
+    await waitFor(() => expect(r2.current.capabilities).toEqual(BASE_CAPS));
+  });
+});
+
+// ── SWR — stale-while-revalidate ──────────────────────────────────────────────
+
+describe('useAnchorCapabilities — stale-while-revalidate', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('returns stale data immediately on mount with warm cache', async () => {
+    const fetch = makeFetch(BASE_CAPS, FULL_CAPS);
+
+    // Populate the cache.
+    const { unmount } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // New consumer: should see stale data before revalidation completes.
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    expect(result.current.capabilities).toEqual(BASE_CAPS);
+    expect(result.current.isLoading).toBe(false); // not blocking
+  });
+
+  test('updates to fresh data after background revalidation', async () => {
+    const fetch = makeFetch(BASE_CAPS, FULL_CAPS);
+
+    const { unmount } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    unmount();
+
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(FULL_CAPS));
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not set isLoading=true during background revalidation', async () => {
+    const fetch = makeFetch(BASE_CAPS, FULL_CAPS);
+
+    const { unmount } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    unmount();
+
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    // isLoading must remain false throughout — never flickers true
+    const loadingValues: boolean[] = [result.current.isLoading];
+    await waitFor(() => expect(result.current.capabilities).toEqual(FULL_CAPS));
+    loadingValues.push(result.current.isLoading);
+
+    expect(loadingValues.every(v => v === false)).toBe(true);
+  });
+});
+
+// ── mutate ────────────────────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — mutate', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('mutate forces a fresh fetch', async () => {
+    const fetch = makeFetch(BASE_CAPS, FULL_CAPS);
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    act(() => { result.current.mutate(); });
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(FULL_CAPS));
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('mutate evicts the cache so isLoading becomes true', async () => {
+    const fetch = makeFetch(BASE_CAPS, FULL_CAPS);
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    act(() => { result.current.mutate(); });
+
+    // Cache evicted: no data + fetching → isLoading=true
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.capabilities).toBeNull();
+  });
+
+  test('mutate clears a previous error and retries', async () => {
+    const fetch = jest.fn()
+      .mockRejectedValueOnce(new Error('network timeout'))
+      .mockResolvedValueOnce(BASE_CAPS);
+
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error!.message).toBe('network timeout');
+
+    act(() => { result.current.mutate(); });
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+    expect(result.current.error).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('mutate is a no-op when attestor is invalid', () => {
+    const fetch = jest.fn();
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(null, { fetchCapabilities: fetch })
+    );
+
+    act(() => { result.current.mutate(); });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — error handling', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('sets error when fetchCapabilities rejects', async () => {
+    const fetch = jest.fn().mockRejectedValue(new Error('contract error'));
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error!.message).toBe('contract error');
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('wraps non-Error rejections', async () => {
+    const fetch = jest.fn().mockRejectedValue('ServicesNotConfigured');
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error!.message).toBe('ServicesNotConfigured');
+  });
+
+  test('clears error on next successful fetch after background revalidation', async () => {
+    // First mount: error
+    const fetch = jest.fn()
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockResolvedValue(BASE_CAPS);
+
+    const { unmount } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // Second mount: should succeed and clear error
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch })
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+    expect(result.current.error).toBeNull();
+  });
+
+  test('preserves stale data when background revalidation fails', async () => {
+    const fetch = makeFetch(BASE_CAPS);
+    // fetchFn always returns BASE_CAPS for first call
+    const fetchWithError = jest.fn()
+      .mockResolvedValueOnce(BASE_CAPS)
+      .mockRejectedValueOnce(new Error('revalidation failed'));
+
+    const { unmount } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetchWithError })
+    );
+    await waitFor(() => expect(fetchWithError).toHaveBeenCalledTimes(1));
+    unmount();
+
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetchWithError })
+    );
+
+    // Returns stale data immediately
+    expect(result.current.capabilities).toEqual(BASE_CAPS);
+
+    // Revalidation fails — but stale data is preserved
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.capabilities).toEqual(BASE_CAPS);
+    expect(result.current.error!.message).toBe('revalidation failed');
+  });
+});
+
+// ── Skip conditions ───────────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — skip conditions', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('does not fetch when attestor is null', () => {
+    const fetch = jest.fn();
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(null, { fetchCapabilities: fetch })
+    );
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('does not fetch when attestor is undefined', () => {
+    const fetch = jest.fn();
+    renderHook(() => useAnchorCapabilities(undefined, { fetchCapabilities: fetch }));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['empty string', ''],
+    ['too short', 'GABC'],
+    ['wrong leading char', 'X' + 'A'.repeat(55)],
+    ['invalid base32 char', 'G' + 'A'.repeat(54) + '0'], // '0' is not in A-Z or 2-7
+    ['too long', 'G' + 'A'.repeat(56)],
+    ['lowercase', 'g' + 'a'.repeat(55)],
+  ])('does not fetch for invalid attestor: %s', (_, addr) => {
+    const fetch = jest.fn();
+    renderHook(() => useAnchorCapabilities(addr, { fetchCapabilities: fetch }));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('accepts a valid C-address (contract ID)', async () => {
+    const contractAddr = 'C' + 'A'.repeat(55);
+    const caps: AnchorServicesResult = { anchor: contractAddr, services: [SERVICE_DEPOSITS] };
+    const fetch = jest.fn().mockResolvedValue(caps);
+
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(contractAddr, { fetchCapabilities: fetch })
+    );
+    await waitFor(() => expect(result.current.capabilities).toEqual(caps));
+    expect(fetch).toHaveBeenCalledWith(contractAddr);
+  });
+
+  test('does not fetch when enabled is false', () => {
+    const fetch = jest.fn();
+    const { result } = renderHook(() =>
+      useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch, enabled: false })
+    );
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('starts fetching when enabled toggles from false to true', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch, enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops revalidating when enabled toggles from true to false', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fetch, enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const callsBefore = fetch.mock.calls.length;
+
+    rerender({ enabled: false });
+
+    // No further fetches should be triggered.
+    await waitFor(() => expect(fetch.mock.calls.length).toBeGreaterThanOrEqual(callsBefore));
+    expect(fetch.mock.calls.length).toBeLessThanOrEqual(callsBefore + 1); // at most the revalidation in progress
+  });
+});
+
+// ── fetchCapabilities reference stability ─────────────────────────────────────
+
+describe('useAnchorCapabilities — inline fetchCapabilities stability', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('reference change does not restart the fetch or reset capabilities', async () => {
+    const fetch1 = jest.fn().mockResolvedValue(BASE_CAPS);
+    const fetch2 = jest.fn().mockResolvedValue(FULL_CAPS);
+
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: jest.Mock }) =>
+        useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fn }),
+      { initialProps: { fn: fetch1 } }
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+    expect(fetch1).toHaveBeenCalledTimes(1);
+
+    rerender({ fn: fetch2 });
+
+    // Effect did not re-run (key unchanged) → fetch2 was NOT called.
+    expect(fetch2).not.toHaveBeenCalled();
+    // Capabilities remain from the first fetch.
+    expect(result.current.capabilities).toEqual(BASE_CAPS);
+  });
+
+  test('when mutate is called after ref change, the new function is used', async () => {
+    const fetch1 = jest.fn().mockResolvedValue(BASE_CAPS);
+    const fetch2 = jest.fn().mockResolvedValue(FULL_CAPS);
+
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: jest.Mock }) =>
+        useAnchorCapabilities(ATTESTOR, { fetchCapabilities: fn }),
+      { initialProps: { fn: fetch1 } }
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    rerender({ fn: fetch2 });
+
+    act(() => { result.current.mutate(); });
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(FULL_CAPS));
+    expect(fetch2).toHaveBeenCalledTimes(1);
+    expect(fetch1).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── attestor key change ───────────────────────────────────────────────────────
+
+describe('useAnchorCapabilities — attestor key change', () => {
+  beforeEach(() => clearCapabilitiesCache());
+
+  test('fetches new attestor when key changes', async () => {
+    const caps2: AnchorServicesResult = { anchor: ATTESTOR_2, services: [SERVICE_KYC] };
+    const fetch = jest.fn()
+      .mockResolvedValueOnce(BASE_CAPS)
+      .mockResolvedValueOnce(caps2);
+
+    const { result, rerender } = renderHook(
+      ({ addr }: { addr: string }) =>
+        useAnchorCapabilities(addr, { fetchCapabilities: fetch }),
+      { initialProps: { addr: ATTESTOR } }
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    rerender({ addr: ATTESTOR_2 });
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(caps2));
+    expect(fetch).toHaveBeenNthCalledWith(1, ATTESTOR);
+    expect(fetch).toHaveBeenNthCalledWith(2, ATTESTOR_2);
+  });
+
+  test('resets to loading state when switching to an uncached attestor', async () => {
+    // Use a controlled promise for the second fetch so it doesn't resolve inside
+    // rerender's act() boundary — this lets us observe the in-flight loading state.
+    let resolveAttesor2!: (v: AnchorServicesResult) => void;
+    const caps2: AnchorServicesResult = { anchor: ATTESTOR_2, services: [SERVICE_KYC] };
+    const slowPromise = new Promise<AnchorServicesResult>(r => { resolveAttesor2 = r; });
+
+    const fetch = jest.fn()
+      .mockResolvedValueOnce(BASE_CAPS)
+      .mockReturnValueOnce(slowPromise);
+
+    const { result, rerender } = renderHook(
+      ({ addr }: { addr: string }) =>
+        useAnchorCapabilities(addr, { fetchCapabilities: fetch }),
+      { initialProps: { addr: ATTESTOR } }
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    rerender({ addr: ATTESTOR_2 });
+
+    // slowPromise hasn't resolved → in-flight → isLoading=true, capabilities=null.
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(result.current.capabilities).toBeNull();
+
+    // Resolve and confirm final state.
+    act(() => { resolveAttesor2(caps2); });
+    await waitFor(() => expect(result.current.capabilities).toEqual(caps2));
+  });
+
+  test('clears state when switching to a null attestor', async () => {
+    const fetch = jest.fn().mockResolvedValue(BASE_CAPS);
+    const { result, rerender } = renderHook(
+      ({ addr }: { addr: string | null }) =>
+        useAnchorCapabilities(addr, { fetchCapabilities: fetch }),
+      { initialProps: { addr: ATTESTOR as string | null } }
+    );
+
+    await waitFor(() => expect(result.current.capabilities).toEqual(BASE_CAPS));
+
+    rerender({ addr: null });
+
+    expect(result.current.capabilities).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/ui/hooks/useAnchorCapabilities.ts
+++ b/ui/hooks/useAnchorCapabilities.ts
@@ -1,0 +1,224 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { unstable_batchedUpdates } from 'react-dom';
+
+// ── Service constants ─────────────────────────────────────────────────────────
+// Mirror of src/types.rs SERVICE_* constants kept in sync with the on-chain values.
+
+export const SERVICE_DEPOSITS    = 1;
+export const SERVICE_WITHDRAWALS = 2;
+export const SERVICE_QUOTES      = 3;
+export const SERVICE_KYC         = 4;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/** TypeScript mirror of the Soroban AnchorServices contract type. */
+export interface AnchorServicesResult {
+  anchor: string;
+  services: number[];
+}
+
+/**
+ * Function that calls `get_supported_services(attestor)` on the contract layer
+ * and resolves with the structured result.
+ */
+export type FetchCapabilitiesFn = (attestor: string) => Promise<AnchorServicesResult>;
+
+export interface UseAnchorCapabilitiesOptions {
+  /** Function that calls `get_supported_services` via the contract layer. */
+  fetchCapabilities: FetchCapabilitiesFn;
+  /** Set to false to skip fetching (e.g. while waiting for auth). Defaults to true. */
+  enabled?: boolean;
+}
+
+export interface UseAnchorCapabilitiesResult {
+  /** Resolved AnchorServices, or null while loading / on error / when attestor is absent. */
+  capabilities: AnchorServicesResult | null;
+  /** True only during the initial (no-cache) fetch; false during background revalidation. */
+  isLoading: boolean;
+  /** Last fetch error. Cleared on the next successful fetch. */
+  error: Error | null;
+  /** Evict the cached entry and force an immediate refetch. */
+  mutate: () => void;
+}
+
+// ── Module-level SWR cache ────────────────────────────────────────────────────
+// Shared across all hook instances so multiple components using the same attestor
+// key share one in-flight request and one cached result.
+
+interface CacheEntry {
+  data: AnchorServicesResult;
+  fetchedAt: number;
+}
+
+const cache       = new Map<string, CacheEntry>();
+const inFlight    = new Map<string, Promise<AnchorServicesResult>>();
+const subscribers = new Map<string, Set<() => void>>();
+
+function subscribe(key: string, listener: () => void): () => void {
+  if (!subscribers.has(key)) subscribers.set(key, new Set());
+  subscribers.get(key)!.add(listener);
+  return () => subscribers.get(key)?.delete(listener);
+}
+
+function notify(key: string): void {
+  // Batch all subscriber state updates into a single React render cycle.
+  // This also satisfies React Testing Library's act() boundary in tests.
+  unstable_batchedUpdates(() => {
+    subscribers.get(key)?.forEach(fn => fn());
+  });
+}
+
+/**
+ * Validates a Stellar StrKey address.
+ * Accepts G-addresses (Ed25519 public keys) and C-addresses (contract IDs):
+ * both are 56 characters of Base32 (A-Z, 2-7).
+ */
+function isValidAttestor(v: string | null | undefined): v is string {
+  if (!v || typeof v !== 'string') return false;
+  return v.length === 56 && /^[GC][A-Z2-7]{55}$/.test(v);
+}
+
+async function fetchAndCache(
+  key: string,
+  fetchFn: FetchCapabilitiesFn,
+): Promise<AnchorServicesResult> {
+  // Deduplicate: if there is already an in-flight request for this key, reuse it.
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = fetchFn(key)
+    .then(data => {
+      cache.set(key, { data, fetchedAt: Date.now() });
+      inFlight.delete(key);
+      notify(key); // wake all cross-component subscribers
+      return data;
+    })
+    .catch(err => {
+      inFlight.delete(key);
+      throw err;
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Evict all cached entries and cancel deduplication state.
+ * Intended for use in tests between cases to ensure isolation.
+ */
+export function clearCapabilitiesCache(): void {
+  cache.clear();
+  inFlight.clear();
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+interface LocalState {
+  isFetching: boolean;
+  error: Error | null;
+  /** Incremented to force a re-read from the module-level cache map. */
+  tick: number;
+}
+
+/**
+ * Calls `get_supported_services(attestor)` via the provided `fetchCapabilities`
+ * function and caches the result using a stale-while-revalidate strategy.
+ *
+ * - Results are shared across all consumers of the same `attestor` key.
+ * - Only one in-flight request is made even when multiple components mount
+ *   simultaneously with the same attestor.
+ * - Mounting with a cached entry returns stale data immediately and revalidates
+ *   in the background without showing a loading state.
+ * - Skips all requests when `attestor` is null/undefined or fails StrKey
+ *   validation, and when `options.enabled` is false.
+ *
+ * @example
+ * const { capabilities, isLoading, error, mutate } = useAnchorCapabilities(attestorAddr, {
+ *   fetchCapabilities: (id) => contract.get_supported_services(id),
+ * });
+ */
+export function useAnchorCapabilities(
+  attestor: string | null | undefined,
+  options: UseAnchorCapabilitiesOptions,
+): UseAnchorCapabilitiesResult {
+  const { enabled = true } = options;
+
+  // Ref so that callers passing inline arrow functions don't restart the effect.
+  const fetchFnRef = useRef<FetchCapabilitiesFn>(options.fetchCapabilities);
+  fetchFnRef.current = options.fetchCapabilities;
+
+  const key = isValidAttestor(attestor) && enabled ? attestor : null;
+
+  // Initialise isFetching=true when there is a valid key but no cached entry,
+  // so the very first render already reports isLoading=true.
+  const [localState, setLocalState] = useState<LocalState>(() => ({
+    isFetching: key !== null && !cache.has(key),
+    error: null,
+    tick: 0,
+  }));
+
+  useEffect(() => {
+    if (!key) {
+      setLocalState({ isFetching: false, error: null, tick: 0 });
+      return;
+    }
+
+    let cancelled = false;
+
+    // Subscribe to cache updates pushed by other components' fetches.
+    const unsubscribe = subscribe(key, () => {
+      if (!cancelled) setLocalState(s => ({ ...s, tick: s.tick + 1 }));
+    });
+
+    // SWR: if no cache entry, mark as loading; otherwise revalidate silently.
+    if (!cache.has(key)) {
+      setLocalState(s => ({ ...s, isFetching: true, error: null }));
+    }
+
+    fetchAndCache(key, id => fetchFnRef.current(id))
+      .then(() => {
+        if (cancelled) return;
+        setLocalState(s => ({ ...s, isFetching: false, error: null, tick: s.tick + 1 }));
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setLocalState(s => ({
+          ...s,
+          isFetching: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [key]);
+
+  // Derive from cache on every render; tick changes force re-reads after updates.
+  const capabilities = key ? (cache.get(key)?.data ?? null) : null;
+
+  // isLoading is only true when we have no data yet — background revalidation
+  // (which always has capabilities !== null) does not set isLoading.
+  const isLoading = localState.isFetching && capabilities === null;
+
+  const mutate = useCallback(() => {
+    if (!key) return;
+    cache.delete(key);
+    inFlight.delete(key);
+    setLocalState(s => ({ ...s, isFetching: true, error: null }));
+    fetchAndCache(key, id => fetchFnRef.current(id))
+      .then(() =>
+        setLocalState(s => ({ ...s, isFetching: false, tick: s.tick + 1 }))
+      )
+      .catch(err =>
+        setLocalState(s => ({
+          ...s,
+          isFetching: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        }))
+      );
+  }, [key]);
+
+  return { capabilities, isLoading, error: localState.error, mutate };
+}

--- a/ui/hooks/useTransactionStatus.test.ts
+++ b/ui/hooks/useTransactionStatus.test.ts
@@ -1,0 +1,371 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTransactionStatus } from './useTransactionStatus';
+import { TransactionStateTracker, isTerminalStatus } from './TransactionStateTracker';
+import { TxStatus } from '../components/TransactionTimeline';
+
+// ─── TransactionStateTracker unit tests ───────────────────────────────────────
+
+describe('TransactionStateTracker', () => {
+  test('records the first transition from null', async () => {
+    const fetch = jest.fn().mockResolvedValue('pending' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.status).toBe('pending');
+    expect(snap.transitions).toHaveLength(1);
+    expect(snap.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+    expect(typeof snap.transitions[0].at).toBe('number');
+  });
+
+  test('records a transition when status changes', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce('pending' as TxStatus)
+      .mockResolvedValueOnce('processing' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.status).toBe('processing');
+    expect(snap.transitions).toHaveLength(2);
+    expect(snap.transitions[1]).toMatchObject({ from: 'pending', to: 'processing' });
+  });
+
+  test('does not add a transition when status is unchanged', async () => {
+    const fetch = jest.fn().mockResolvedValue('pending' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    const snap = await tracker.poll('tx1');
+
+    expect(snap.transitions).toHaveLength(1);
+  });
+
+  test('getSnapshot throws before first poll', () => {
+    const tracker = new TransactionStateTracker(jest.fn());
+    expect(() => tracker.getSnapshot()).toThrow('No status polled yet');
+  });
+
+  test('reset clears status and transitions', async () => {
+    const fetch = jest.fn().mockResolvedValue('processing' as TxStatus);
+    const tracker = new TransactionStateTracker(fetch);
+
+    await tracker.poll('tx1');
+    tracker.reset();
+
+    expect(() => tracker.getSnapshot()).toThrow();
+  });
+
+  test.each<[TxStatus, boolean]>([
+    ['initiated', false],
+    ['pending', false],
+    ['processing', false],
+    ['completed', true],
+    ['failed', true],
+  ])('isTerminalStatus(%s) === %s', (status, expected) => {
+    expect(isTerminalStatus(status)).toBe(expected);
+  });
+});
+
+// ─── useTransactionStatus hook tests ─────────────────────────────────────────
+
+describe('useTransactionStatus', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // ── Pending state ────────────────────────────────────────────────────────
+
+  test('returns null status before first poll resolves', () => {
+    const fetchStatus = jest.fn(() => new Promise<TxStatus>(() => {})); // never resolves
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus })
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.transitions).toEqual([]);
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('sets status after first poll resolves', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.transitions).toHaveLength(1);
+    expect(result.current.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+  });
+
+  // ── Transitioning ────────────────────────────────────────────────────────
+
+  test('records transitions as status advances', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce('pending' as TxStatus)
+      .mockResolvedValueOnce('processing' as TxStatus)
+      .mockResolvedValue('completed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('completed'));
+
+    expect(result.current.transitions).toHaveLength(3);
+    expect(result.current.transitions.map(t => t.to)).toEqual([
+      'pending', 'processing', 'completed',
+    ]);
+  });
+
+  // ── Terminal state ───────────────────────────────────────────────────────
+
+  test('stops polling when completed is reached', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('completed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+    expect(result.current.status).toBe('completed');
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  test('stops polling when failed is reached', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('failed' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+    expect(result.current.status).toBe('failed');
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Error scenarios ──────────────────────────────────────────────────────
+
+  test('sets error when fetchStatus rejects', async () => {
+    const fetchStatus = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.status).toBeNull();
+  });
+
+  test('retries after an error', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValue('processing' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => { jest.advanceTimersByTime(100); });
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+    expect(result.current.error).toBeNull();
+  });
+
+  test('wraps non-Error rejections in an Error', async () => {
+    const fetchStatus = jest.fn().mockRejectedValue('string error');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string error');
+  });
+
+  // ── Cleanup on unmount ───────────────────────────────────────────────────
+
+  test('clears pending timer and does not update state after unmount', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValue('pending' as TxStatus);
+
+    const { result, unmount } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 100 })
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+
+    unmount();
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(300); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Options: enabled flag ────────────────────────────────────────────────
+
+  test('does not poll when enabled is false', () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { result } = renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, enabled: false })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+    expect(result.current.status).toBeNull();
+  });
+
+  test('starts polling when enabled transitions from false to true', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('processing' as TxStatus);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useTransactionStatus('tx1', { fetchStatus, enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.status).toBe('processing'));
+  });
+
+  test('stops polling when enabled transitions from true to false', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useTransactionStatus('tx1', { fetchStatus, enabled, interval: 100 }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+
+    rerender({ enabled: false });
+
+    const callsBefore = fetchStatus.mock.calls.length;
+    act(() => { jest.advanceTimersByTime(300); });
+    expect(fetchStatus.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Options: interval ────────────────────────────────────────────────────
+
+  test('respects custom polling interval', async () => {
+    const fetchStatus = jest.fn().mockResolvedValue('pending' as TxStatus);
+
+    renderHook(() =>
+      useTransactionStatus('tx1', { fetchStatus, interval: 1000 })
+    );
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalledTimes(1));
+
+    act(() => { jest.advanceTimersByTime(999); });
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    act(() => { jest.advanceTimersByTime(1); });
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalledTimes(2));
+  });
+
+  // ── Invalid / null txId ──────────────────────────────────────────────────
+
+  test('does not poll when txId is null', () => {
+    const fetchStatus = jest.fn();
+
+    renderHook(() =>
+      useTransactionStatus(null, { fetchStatus })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  test('does not poll when txId is undefined', () => {
+    const fetchStatus = jest.fn();
+
+    renderHook(() =>
+      useTransactionStatus(undefined, { fetchStatus })
+    );
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  test('resets state when txId changes', async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce('completed' as TxStatus)
+      .mockResolvedValue('pending' as TxStatus);
+
+    const { result, rerender } = renderHook(
+      ({ txId }: { txId: string }) =>
+        useTransactionStatus(txId, { fetchStatus, interval: 100 }),
+      { initialProps: { txId: 'tx1' } }
+    );
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true));
+
+    rerender({ txId: 'tx2' });
+
+    await waitFor(() => expect(result.current.status).toBe('pending'));
+    expect(result.current.isTerminal).toBe(false);
+    expect(result.current.transitions[0]).toMatchObject({ from: null, to: 'pending' });
+  });
+
+  // ── Inline fetchStatus stability ─────────────────────────────────────────
+
+  test('does not restart polling when fetchStatus reference changes', async () => {
+    let callCount = 0;
+    const fetchStatus = jest.fn(async () => {
+      callCount++;
+      return 'pending' as TxStatus;
+    });
+
+    const { rerender } = renderHook(
+      ({ fn }: { fn: typeof fetchStatus }) =>
+        useTransactionStatus('tx1', { fetchStatus: fn, interval: 500 }),
+      { initialProps: { fn: fetchStatus } }
+    );
+
+    await waitFor(() => expect(callCount).toBeGreaterThan(0));
+    const snapshot = callCount;
+
+    // Pass a new function reference — should NOT restart the effect / reset transitions
+    const fetchStatus2 = jest.fn(async () => 'pending' as TxStatus);
+    rerender({ fn: fetchStatus2 });
+
+    act(() => { jest.advanceTimersByTime(0); });
+    // The effect should not have restarted (no extra calls from a fresh poll)
+    expect(callCount).toBe(snapshot);
+  });
+});

--- a/ui/hooks/useTransactionStatus.ts
+++ b/ui/hooks/useTransactionStatus.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react';
+import { TxStatus } from '../components/TransactionTimeline';
+import {
+  TransactionStateTracker,
+  TransactionSnapshot,
+  TransactionTransition,
+  FetchStatusFn,
+} from './TransactionStateTracker';
+
+export type { FetchStatusFn, TransactionTransition, TransactionSnapshot };
+
+export interface UseTransactionStatusOptions {
+  /** Function that fetches the current status for a given transaction ID. */
+  fetchStatus: FetchStatusFn;
+  /** Polling interval in milliseconds. Defaults to 5000. */
+  interval?: number;
+  /** Set to false to pause polling without unmounting. Defaults to true. */
+  enabled?: boolean;
+}
+
+export interface UseTransactionStatusResult {
+  /** Current transaction status, or null before the first poll completes. */
+  status: TxStatus | null;
+  /** Ordered list of recorded status transitions. */
+  transitions: TransactionTransition[];
+  /** True when status is "completed" or "failed" (polling has stopped). */
+  isTerminal: boolean;
+  /** Last fetch error, if any. Cleared on the next successful poll. */
+  error: Error | null;
+}
+
+/**
+ * Polls a TransactionStateTracker for the given txId and exposes a consistent
+ * status interface. Polling starts automatically when txId is valid and
+ * enabled is true, stops once a terminal state is reached, and cleans up
+ * timers on unmount.
+ *
+ * @example
+ * const { status, transitions, isTerminal } = useTransactionStatus(txId, {
+ *   fetchStatus: (id) => api.getTransactionStatus(id),
+ *   interval: 3000,
+ * });
+ */
+export function useTransactionStatus(
+  txId: string | null | undefined,
+  options: UseTransactionStatusOptions
+): UseTransactionStatusResult {
+  const { interval = 5000, enabled = true } = options;
+
+  // Ref so that an inline fetchStatus function doesn't restart the polling loop
+  const fetchStatusRef = useRef<FetchStatusFn>(options.fetchStatus);
+  fetchStatusRef.current = options.fetchStatus;
+
+  const [snapshot, setSnapshot] = useState<TransactionSnapshot | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!txId || !enabled) {
+      setSnapshot(null);
+      setError(null);
+      return;
+    }
+
+    const tracker = new TransactionStateTracker((id) => fetchStatusRef.current(id));
+    let cancelled = false;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const snap = await tracker.poll(txId);
+        if (cancelled) return;
+        setSnapshot(snap);
+        setError(null);
+        if (!snap.isTerminal) {
+          timerId = setTimeout(poll, interval);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        timerId = setTimeout(poll, interval);
+      }
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) clearTimeout(timerId);
+      tracker.reset();
+    };
+  }, [txId, enabled, interval]);
+
+  return {
+    status: snapshot?.status ?? null,
+    transitions: snapshot?.transitions ?? [],
+    isTerminal: snapshot?.isTerminal ?? false,
+    error,
+  };
+}

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/components'],
+  roots: ['<rootDir>/components', '<rootDir>/hooks'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: [


### PR DESCRIPTION
Closes #692

---

## Summary

- Adds `useAnchorCapabilities(attestor, options)` hook that calls `get_supported_services` on the Soroban contract via an injectable `fetchCapabilities` function, making it testable without mocking the entire contract layer.
- Implements a **stale-while-revalidate** caching strategy at module level: stale data is returned immediately on mount with a warm cache, while a background revalidation runs — `isLoading` stays `false` during background work.
- **In-flight deduplication**: multiple components mounting with the same attestor key share one network request and one cache entry via a `Map<key, Promise>` guard.
- Returns `{ capabilities, isLoading, error, mutate }` — `mutate()` evicts the cache entry and forces an immediate refetch with `isLoading: true`.
- Skips all fetches when `attestor` is null/undefined/invalid Stellar StrKey, or when `options.enabled` is false.
- Exports `SERVICE_DEPOSITS`, `SERVICE_WITHDRAWALS`, `SERVICE_QUOTES`, `SERVICE_KYC` constants (mirrors of `src/types.rs`), `AnchorServicesResult`, `FetchCapabilitiesFn`, and `clearCapabilitiesCache` (for test isolation) from the hooks barrel.

## Files changed

| File | Description |
|------|-------------|
| `ui/hooks/useAnchorCapabilities.ts` | Hook implementation with module-level SWR cache, in-flight deduplication, subscriber notification, and Stellar StrKey validation |
| `ui/hooks/useAnchorCapabilities.test.ts` | 35 tests across 7 describe groups covering all hook behaviors |
| `ui/hooks/index.ts` | Barrel exports for the new hook, types, constants, and `clearCapabilitiesCache` |

## Design decisions

**Injectable fetch function** — callers provide `fetchCapabilities: (attestor) => Promise<AnchorServicesResult>` rather than the hook importing the contract client directly. This keeps the hook decoupled from the RPC transport layer and makes unit tests straightforward without any module-level mocking.

**`fetchFnRef` pattern** — the fetch function is stored in a ref so callers that pass inline arrow functions don't cause the effect to restart on every render. When `mutate()` is called after a ref change, it uses the latest function.

**`isLoading` semantics** — defined as `isFetching && capabilities === null`. This means it is `true` only during the initial cold-cache fetch. Background SWR revalidation (which always has a non-null stale value available) never sets `isLoading: true`, avoiding loading-skeleton flicker on re-mounts.

**`unstable_batchedUpdates`** — subscriber notifications that push cache updates to multiple components are batched into a single React render cycle, avoiding cascading re-renders and satisfying `act()` boundaries in tests.

## Test plan

- [x] `useAnchorCapabilities — successful fetch` (3 tests) — isLoading lifecycle, fetch call args, service codes
- [x] `useAnchorCapabilities — caching` (4 tests) — warm-cache second consumer, concurrent deduplication, independent keys, cross-component subscriber notification
- [x] `useAnchorCapabilities — stale-while-revalidate` (3 tests) — stale data on mount, background update, no isLoading flicker
- [x] `useAnchorCapabilities — mutate` (4 tests) — forces refetch, evicts cache, clears errors, no-op when invalid
- [x] `useAnchorCapabilities — error handling` (4 tests) — Error and non-Error rejections, error clear on success, stale-data preservation on failed revalidation
- [x] `useAnchorCapabilities — skip conditions` (11 tests) — null/undefined/invalid attestors (6 cases), C-address, `enabled` toggle, start/stop behavior
- [x] `useAnchorCapabilities — fetchCapabilities reference stability` (2 tests) — no effect restart on ref change, mutate uses latest ref
- [x] `useAnchorCapabilities — attestor key change` (3 tests) — refetches new key, loading state for uncached key, clears on null
- [x] All 35 tests pass; pre-existing component test failures are unrelated to this PR

