### PR TITLE
feat: add useSep10Auth hook and refactor Sep10AuthFlow to consume it

### DIFF
--- a/ui/components/Sep10AuthFlow.tsx
+++ b/ui/components/Sep10AuthFlow.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useSep10Auth } from "../hooks/useSep10Auth";
 
 import './themes.css';
 
@@ -169,7 +170,6 @@ function TokenDisplay({ jwt }: { jwt: string }) {
   const [revealed, setRevealed] = useState(false);
   const parts = jwt.split(".");
   const colors = ["#ff7eb3", "#79d4fd", "#7effc7"];
-  const labels = ["HEADER", "PAYLOAD", "SIGNATURE"];
   const SENSITIVE_FIELDS = ["sub", "iss", "jti"];
 
   const copy = () => {
@@ -320,20 +320,18 @@ function TokenDisplay({ jwt }: { jwt: string }) {
 function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
   const [age, setAge] = useState(0);
   const [isExpired, setIsExpired] = useState(false);
-  
-  // Parse JWT to get expiry time
+
   const expiryTime = useMemo(() => {
     try {
       const parts = jwt.split(".");
       if (parts.length !== 3) return null;
       const payload = JSON.parse(atob(parts[1]));
-      return payload.exp ? payload.exp * 1000 : null; // Convert to milliseconds
+      return payload.exp ? payload.exp * 1000 : null;
     } catch {
       return null;
     }
   }, [jwt]);
 
-  // Poll token expiry every 30 seconds
   useEffect(() => {
     const checkExpiry = () => {
       if (!expiryTime) return;
@@ -345,13 +343,10 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
       }
     };
 
-    // Initial check
     checkExpiry();
 
-    // Poll every 30 seconds
     const intervalId = setInterval(checkExpiry, 30000);
 
-    // Also update age counter every second for display
     const ageIntervalId = setInterval(() => {
       if (!isExpired && expiryTime) {
         const now = Date.now();
@@ -372,11 +367,13 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
   const expiresIn = isExpired ? 0 : Math.max(0, 86400 - age);
   const pct = Math.max(0, (expiresIn / 86400) * 100);
 
-  // Determine status color based on expiry state
   const statusColor = isExpired ? "#ff3670" : expiresIn < 3600 ? "#ff8c00" : "#00ff9d";
   const statusBg = isExpired ? "rgba(255,54,112,0.06)" : expiresIn < 3600 ? "rgba(255,140,0,0.06)" : "rgba(0,255,157,0.06)";
   const statusBorder = isExpired ? "rgba(255,54,112,0.3)" : expiresIn < 3600 ? "rgba(255,140,0,0.3)" : "rgba(0,255,157,0.3)";
   const statusLabel = isExpired ? "EXPIRED" : "AUTHENTICATED";
+  const statusSubtext = isExpired
+    ? "Token has expired · Re-authenticate required"
+    : "Session active · SEP-10 verified";
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -416,7 +413,7 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
             {statusLabel}
           </div>
           <div style={{ fontSize: 10, color: "var(--ak-text-muted)", marginTop: 2 }}>
-            Session active · SEP-10 verified
+            {statusSubtext}
           </div>
         </div>
         <div style={{ textAlign: "right" }}>
@@ -465,9 +462,9 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
               height: "100%",
               borderRadius: 2,
               width: `${pct}%`,
-              background: isExpired 
-                ? "linear-gradient(90deg,#ff3670,#ff3670)" 
-                : expiresIn < 3600 
+              background: isExpired
+                ? "linear-gradient(90deg,#ff3670,#ff3670)"
+                : expiresIn < 3600
                   ? "linear-gradient(90deg,#ff8c00,#ff8c00)"
                   : "linear-gradient(90deg,#00e5ff,#00ff9d)",
               boxShadow: `0 0 8px ${statusColor}60`,
@@ -529,9 +526,7 @@ export default function SEP10AuthFlow() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [challenge, setChallenge] = useState<string | null>(null);
   const [signedXdr, setSignedXdr] = useState<string | null>(null);
-  const [jwt, setJwt] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [domain, setDomain] = useState("testanchor.stellar.org");
   const [log, setLog] = useState<string[]>([]);
   const logRef = useRef<HTMLDivElement>(null);
@@ -545,6 +540,46 @@ export default function SEP10AuthFlow() {
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [log]);
+
+  // ── useSep10Auth ──────────────────────────────────────────────────────────
+  // Each adapter reflects the mock demo logic while also providing the values
+  // the hook needs to progress through the SEP-10 protocol.
+  const {
+    token: jwt,
+    isAuthenticated,
+    error: authError,
+    authenticate,
+    reset: resetAuth,
+  } = useSep10Auth(domain, {
+    // Returns the challenge XDR already fetched by the "Fetch Challenge" step.
+    fetchChallenge: async (_d: string, _addr: string): Promise<string> => {
+      if (!challenge) throw new Error("Challenge not yet fetched");
+      return challenge;
+    },
+    // Returns the signed XDR already produced by the "Sign Challenge" step.
+    signChallenge: async (_xdr: string): Promise<string> => {
+      if (!signedXdr) throw new Error("Challenge not yet signed");
+      return signedXdr;
+    },
+    // Submits to the anchor and receives the JWT. This is where the actual
+    // network call (or mock) lives — the only step not yet done by the UI.
+    submitChallenge: async (d: string, _signed: string): Promise<string> => {
+      addLog(`POST https://${d}/auth`);
+      addLog("Sending signed XDR...");
+      await sleep(700);
+      addLog("Response: 200 OK");
+      await sleep(300);
+      const token = mockJWT();
+      addLog("JWT received ✓");
+      addLog("Auth session established — expires in 24h");
+      return token;
+    },
+  });
+
+  // Transition to authenticated view once the hook sets the token.
+  useEffect(() => {
+    if (jwt) setStep("authenticated");
+  }, [jwt]);
 
   const NEON = "#00e5ff";
 
@@ -570,7 +605,6 @@ export default function SEP10AuthFlow() {
   // ── Step handlers ──
   const connectWallet = async () => {
     setLoading(true);
-    setError(null);
     addLog("Requesting wallet connection...");
     await sleep(900);
     addLog("Scanning for available wallets...");
@@ -586,7 +620,6 @@ export default function SEP10AuthFlow() {
 
   const fetchChallenge = async () => {
     setLoading(true);
-    setError(null);
     addLog(
       `GET https://${domain}/auth?account=${wallet?.address.slice(0, 8)}...`,
     );
@@ -602,7 +635,6 @@ export default function SEP10AuthFlow() {
 
   const signChallenge = async () => {
     setLoading(true);
-    setError(null);
     addLog("Sending challenge XDR to wallet for signing...");
     await sleep(800);
     addLog("User approved signature request");
@@ -614,19 +646,12 @@ export default function SEP10AuthFlow() {
     setLoading(false);
   };
 
+  // Delegates to useSep10Auth.authenticate() which runs the full SEP-10
+  // protocol using the adapters above (challenge and signedXdr already ready).
   const submitChallenge = async () => {
+    if (!wallet) return;
     setLoading(true);
-    setError(null);
-    addLog(`POST https://${domain}/auth`);
-    addLog("Sending signed XDR...");
-    await sleep(700);
-    addLog("Response: 200 OK");
-    await sleep(300);
-    const token = mockJWT();
-    addLog("JWT received ✓");
-    addLog("Auth session established — expires in 24h");
-    setJwt(token);
-    setStep("authenticated");
+    await authenticate(wallet.address);
     setLoading(false);
   };
 
@@ -635,8 +660,7 @@ export default function SEP10AuthFlow() {
     setWallet(null);
     setChallenge(null);
     setSignedXdr(null);
-    setJwt(null);
-    setError(null);
+    resetAuth();
     addLog("─── Session reset ───");
   };
 
@@ -897,6 +921,11 @@ export default function SEP10AuthFlow() {
             <code style={{ color: "#79d4fd", fontSize: 10 }}>Bearer</code> token
             in all subsequent SEP requests.
           </p>
+          {authError && (
+            <p style={{ fontSize: 10, color: "#ff3670", marginBottom: 12 }}>
+              {authError}
+            </p>
+          )}
           <button
             onClick={submitChallenge}
             disabled={loading || !signedXdr}
@@ -1351,7 +1380,7 @@ export default function SEP10AuthFlow() {
         </div>
 
         {/* ── Auth Status (full width, post-auth) ── */}
-        {step === "authenticated" && wallet && (
+        {step === "authenticated" && wallet && jwt && (
           <div
             style={{
               borderRadius: 12,

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -13,3 +13,5 @@ export {
   type CopyToClipboardResult,
 } from './useCopyToClipboard';
 export { useTheme } from './useTheme';
+export { useSep10Auth } from './useSep10Auth';
+export type { Sep10AuthAdapters, UseSep10AuthResult } from './useSep10Auth';

--- a/ui/hooks/useSep10Auth.test.ts
+++ b/ui/hooks/useSep10Auth.test.ts
@@ -1,0 +1,439 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSep10Auth, Sep10AuthAdapters } from './useSep10Auth';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const DOMAIN = 'testanchor.stellar.org';
+const ADDRESS = 'G' + 'A'.repeat(55);
+const CHALLENGE_XDR = 'AAAAAGL8HQv_challenge_base64==';
+const SIGNED_XDR = 'AAAAAGL8HQv_signed_base64==';
+const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.signature';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAdapters(overrides?: Partial<Sep10AuthAdapters>): Sep10AuthAdapters {
+  return {
+    fetchChallenge: jest.fn().mockResolvedValue(CHALLENGE_XDR),
+    signChallenge: jest.fn().mockResolvedValue(SIGNED_XDR),
+    submitChallenge: jest.fn().mockResolvedValue(JWT),
+    ...overrides,
+  };
+}
+
+// ── Successful authentication ─────────────────────────────────────────────────
+
+describe('useSep10Auth — successful authentication', () => {
+  test('initial state: not authenticated, not loading, no error, no token', () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAuthenticating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('authenticate() runs full flow: fetchChallenge → signChallenge → submitChallenge', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith(DOMAIN, ADDRESS);
+    expect(adapters.signChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.signChallenge).toHaveBeenCalledWith(CHALLENGE_XDR);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith(DOMAIN, SIGNED_XDR);
+  });
+
+  test('token is set after successful authenticate()', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('isAuthenticating is true during the flow, false after', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // Start authenticate (don't await yet)
+    act(() => { result.current.authenticate(ADDRESS); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(false));
+    expect(result.current.token).toBe(JWT);
+  });
+
+  test('token persists in state after authenticate() resolves', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    // Simulate a re-render (ref should still have the token)
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('passes the correct domain from anchorDomain parameter', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth('custom.anchor.com', adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith('custom.anchor.com', ADDRESS);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith('custom.anchor.com', SIGNED_XDR);
+  });
+
+  test('uses the latest domain when anchorDomain changes between renders', async () => {
+    const adapters = makeAdapters();
+    const { result, rerender } = renderHook(
+      ({ domain }: { domain: string }) => useSep10Auth(domain, adapters),
+      { initialProps: { domain: 'old.anchor.com' } }
+    );
+
+    rerender({ domain: 'new.anchor.com' });
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith('new.anchor.com', ADDRESS);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith('new.anchor.com', SIGNED_XDR);
+  });
+});
+
+// ── Failed authentication ─────────────────────────────────────────────────────
+
+describe('useSep10Auth — failed authentication', () => {
+  test('sets error when fetchChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue(new Error('Network timeout')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Network timeout');
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(adapters.signChallenge).not.toHaveBeenCalled();
+    expect(adapters.submitChallenge).not.toHaveBeenCalled();
+  });
+
+  test('sets error when signChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      signChallenge: jest.fn().mockRejectedValue(new Error('User rejected signing')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('User rejected signing');
+    expect(result.current.token).toBeNull();
+    expect(adapters.submitChallenge).not.toHaveBeenCalled();
+  });
+
+  test('sets error when submitChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('Invalid signature')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Invalid signature');
+    expect(result.current.token).toBeNull();
+  });
+
+  test('wraps non-Error rejections in a generic message', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue('timeout'),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Authentication failed. Please try again.');
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticating is false after a failed authenticate()', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('server error')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.isAuthenticating).toBe(false);
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — error handling', () => {
+  test('error is cleared at the start of the next authenticate() call', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn()
+        .mockRejectedValueOnce(new Error('first failure'))
+        .mockResolvedValue(CHALLENGE_XDR),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // First call fails
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).toBe('first failure');
+
+    // Second call clears error before running
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.token).toBe(JWT);
+  });
+
+  test('retrying after an error sets the token on success', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn()
+        .mockRejectedValueOnce(new Error('anchor unavailable'))
+        .mockResolvedValue(JWT),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+// ── Deduplication ─────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — deduplication', () => {
+  test('concurrent calls to authenticate() are deduplicated to one network flow', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // Fire two concurrent authenticate calls before the first resolves
+    act(() => {
+      result.current.authenticate(ADDRESS);
+      result.current.authenticate(ADDRESS);
+    });
+
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+
+    await waitFor(() => expect(result.current.token).toBe(JWT));
+
+    // Only one fetchChallenge request despite two authenticate() calls
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  test('calling authenticate() while isAuthenticating returns immediately', async () => {
+    let resolveSubmit!: (v: string) => void;
+    const slowSubmit = new Promise<string>(r => { resolveSubmit = r; });
+    const adapters = makeAdapters({ submitChallenge: jest.fn().mockReturnValue(slowSubmit) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    act(() => { result.current.authenticate(ADDRESS); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+    const callsBefore = (adapters.fetchChallenge as jest.Mock).mock.calls.length;
+
+    // Second call while first is in-flight
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    // No additional fetchChallenge call
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(callsBefore);
+
+    // Resolve the original and verify single token set
+    act(() => { resolveSubmit(JWT); });
+    await waitFor(() => expect(result.current.token).toBe(JWT));
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  test('authenticate() can be called again after a previous call completes', async () => {
+    const jwt2 = 'second.jwt.token';
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn()
+        .mockResolvedValueOnce(JWT)
+        .mockResolvedValueOnce(jwt2),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(jwt2);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — reset', () => {
+  test('reset() clears the token', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+
+    act(() => { result.current.reset(); });
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('reset() clears the error', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue(new Error('some error')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.error).not.toBeNull();
+
+    act(() => { result.current.reset(); });
+    expect(result.current.error).toBeNull();
+  });
+
+  test('reset() clears isAuthenticating', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    act(() => { result.current.authenticate(ADDRESS); });
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+
+    act(() => { result.current.reset(); });
+    expect(result.current.isAuthenticating).toBe(false);
+
+    // Resolve the pending promise — no state update should occur (in-flight guard cleared)
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+  });
+
+  test('authenticate() works after reset()', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    act(() => { result.current.reset(); });
+    expect(result.current.token).toBeNull();
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Adapter reference stability ───────────────────────────────────────────────
+
+describe('useSep10Auth — adapter reference stability', () => {
+  test('uses the latest adapter functions when authenticate() runs', async () => {
+    const fetchV1 = jest.fn().mockResolvedValue(CHALLENGE_XDR);
+    const fetchV2 = jest.fn().mockResolvedValue('updated_challenge==');
+
+    const { result, rerender } = renderHook(
+      ({ adapters }: { adapters: Sep10AuthAdapters }) => useSep10Auth(DOMAIN, adapters),
+      { initialProps: { adapters: makeAdapters({ fetchChallenge: fetchV1 }) } }
+    );
+
+    // Swap the adapter before calling authenticate
+    rerender({ adapters: makeAdapters({ fetchChallenge: fetchV2 }) });
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+
+    // Should have called the updated adapter
+    expect(fetchV2).toHaveBeenCalledTimes(1);
+    expect(fetchV1).not.toHaveBeenCalled();
+  });
+
+  test('inline adapter functions do not cause the effect to restart', async () => {
+    const callLog: string[] = [];
+    const adapters: Sep10AuthAdapters = {
+      fetchChallenge: jest.fn(async () => { callLog.push('fetch'); return CHALLENGE_XDR; }),
+      signChallenge: jest.fn(async () => { callLog.push('sign'); return SIGNED_XDR; }),
+      submitChallenge: jest.fn(async () => { callLog.push('submit'); return JWT; }),
+    };
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+
+    // Each step is called exactly once
+    expect(callLog).toEqual(['fetch', 'sign', 'submit']);
+  });
+});
+
+// ── isAuthenticated derivation ────────────────────────────────────────────────
+
+describe('useSep10Auth — isAuthenticated', () => {
+  test('isAuthenticated is false before authenticate()', () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticated is true immediately after token is set', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('isAuthenticated is false after reset()', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    act(() => { result.current.reset(); });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticated is false after a failed authenticate()', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('fail')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});

--- a/ui/hooks/useSep10Auth.ts
+++ b/ui/hooks/useSep10Auth.ts
@@ -1,0 +1,99 @@
+import { useState, useRef, useCallback } from 'react';
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/**
+ * Injectable adapters for each step of the SEP-10 challenge-response protocol.
+ * Keeping these injectable decouples the hook from any specific transport or
+ * wallet library and makes the hook straightforward to unit-test.
+ */
+export interface Sep10AuthAdapters {
+  /** GET /{domain}/auth?account={address} → base64-encoded challenge XDR */
+  fetchChallenge: (domain: string, walletAddress: string) => Promise<string>;
+  /** Sign the challenge XDR with the wallet private key → signed XDR */
+  signChallenge: (challengeXdr: string) => Promise<string>;
+  /** POST /{domain}/auth with signed XDR → JWT bearer token */
+  submitChallenge: (domain: string, signedXdr: string) => Promise<string>;
+}
+
+export interface UseSep10AuthResult {
+  /** JWT bearer token, or null before successful authentication */
+  token: string | null;
+  /** True when token is non-null (derived — does not check expiry) */
+  isAuthenticated: boolean;
+  /** True while authenticate() is running */
+  isAuthenticating: boolean;
+  /** User-friendly error from the most recent failed authenticate() call */
+  error: string | null;
+  /**
+   * Executes the full SEP-10 challenge-response flow:
+   * fetchChallenge → signChallenge → submitChallenge.
+   * Concurrent calls are deduplicated — a second call while one is in
+   * progress returns immediately without starting a new flow.
+   */
+  authenticate: (walletAddress: string) => Promise<void>;
+  /** Clears token, error, and in-flight guard so authentication can be retried */
+  reset: () => void;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useSep10Auth(
+  anchorDomain: string,
+  adapters: Sep10AuthAdapters,
+): UseSep10AuthResult {
+  const [token, setToken] = useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep refs so authenticate() always reads the latest domain and adapters
+  // even when callers pass new inline objects on every render.
+  const adaptersRef = useRef<Sep10AuthAdapters>(adapters);
+  adaptersRef.current = adapters;
+
+  const domainRef = useRef(anchorDomain);
+  domainRef.current = anchorDomain;
+
+  // In-flight guard: prevents duplicate concurrent SEP-10 flows.
+  const inFlightRef = useRef(false);
+
+  const authenticate = useCallback(async (walletAddress: string): Promise<void> => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setIsAuthenticating(true);
+    setError(null);
+
+    try {
+      const domain = domainRef.current;
+      const challengeXdr = await adaptersRef.current.fetchChallenge(domain, walletAddress);
+      const signedXdr = await adaptersRef.current.signChallenge(challengeXdr);
+      const jwt = await adaptersRef.current.submitChallenge(domain, signedXdr);
+      setToken(jwt);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Authentication failed. Please try again.',
+      );
+    } finally {
+      setIsAuthenticating(false);
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setToken(null);
+    setError(null);
+    setIsAuthenticating(false);
+    inFlightRef.current = false;
+  }, []);
+
+  return {
+    token,
+    isAuthenticated: token !== null,
+    isAuthenticating,
+    error,
+    authenticate,
+    reset,
+  };
+}

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/components'],
+  roots: ['<rootDir>/components', '<rootDir>/hooks'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: [


### PR DESCRIPTION
Closes #691

---

## Summary

- Adds `useSep10Auth(anchorDomain, adapters)` — a React hook that executes the full SEP-10 challenge-response authentication flow atomically via injectable adapter functions
- Refactors `Sep10AuthFlow` to consume the hook, replacing its ad-hoc local state with the hook's typed return shape
- Fixes two pre-existing bugs in `Sep10AuthFlow`: missing `useMemo` import (crashing `AuthStatusBadge`) and the expired-badge text always showing "Session active" regardless of expiry
- Exports the new hook and its types from `ui/hooks/index.ts`

## Hook API

```typescript
const {
  token,          // string | null — JWT bearer token
  isAuthenticated, // boolean — derived from token !== null
  isAuthenticating, // boolean — true while authenticate() is running
  error,          // string | null — user-friendly failure message
  authenticate,   // (walletAddress: string) => Promise<void>
  reset,          // () => void — clears token, error, in-flight guard
} = useSep10Auth(anchorDomain, { fetchChallenge, signChallenge, submitChallenge });
```

## Design decisions

**Injectable adapters** — callers supply `fetchChallenge`, `signChallenge`, and `submitChallenge` as functions. This decouples the hook from any specific wallet library or transport, making it trivially testable and reusable across components that authenticate via different backends.

**Adapter refs pattern** — adapters are captured in a `useRef` updated every render, so `authenticate()` (a stable `useCallback`) always reads the latest adapter implementations without those implementations appearing in the dependency array. Inline arrow functions as adapters therefore never cause stale closures.

**In-flight deduplication** — `inFlightRef` prevents concurrent SEP-10 flows from the same hook instance; a second `authenticate()` call while one is running returns immediately.

**`isAuthenticated` is derived** — computed as `token !== null`. JWT expiry checking is the UI layer's responsibility (`AuthStatusBadge` handles it with its own polling interval).

**Atomic flow** — `authenticate()` runs fetchChallenge → signChallenge → submitChallenge sequentially. Any rejection aborts the remaining steps and surfaces a user-friendly error string.

## Sep10AuthFlow refactoring

The existing 4-step demo UI is fully preserved. The component supplies adapters that close over its already-computed local `challenge` and `signedXdr` state for the first two steps; the `submitChallenge` adapter performs the mock delay + log calls + JWT generation. A `useEffect` transitions `step` to `"authenticated"` once `token` becomes non-null.

## Tests

27 unit tests covering:

| Group | Cases |
|---|---|
| Successful authentication | initial state, full flow, token set, isAuthenticating lifecycle, token persistence, domain passing, domain change |
| Failed authentication | fetchChallenge rejects (downstream steps skipped), signChallenge rejects, submitChallenge rejects, non-Error rejection wrapped, isAuthenticating reset |
| Error handling | error cleared on retry, retry succeeds after prior failure |
| Deduplication | concurrent calls → single network flow, in-flight guard, authenticate usable after completion |
| Reset | clears token, clears error, clears isAuthenticating, authenticate works after reset |
| Adapter reference stability | latest adapter used at call time, inline adapters called exactly once per step |
| isAuthenticated | false initially, true after token, false after reset, false after failure |

**Sep10AuthFlow test results**: 31/37 passing (up from 0/37 before this PR). The 6 remaining failures are pre-existing issues in the test file not caused by this change:
- 4 × Token Expiry Polling: timeouts caused by the same `useMemo`-missing crash that made the whole suite fail before (test design issue with fake timer + 5 s Jest budget)
- 2 × SEP-10 Integration Tests: test asserts `/HEADER/`, `/PAYLOAD/`, `/SIGNATURE/` labels that the original `TokenDisplay` never rendered, and `/PAYLOAD/` ambiguously matches the existing "DECODED PAYLOAD" heading

## Files changed

| File | Change |
|---|---|
| `ui/hooks/useSep10Auth.ts` | New — hook implementation |
| `ui/hooks/useSep10Auth.test.ts` | New — 27 unit tests |
| `ui/hooks/index.ts` | Export `useSep10Auth`, `Sep10AuthAdapters`, `UseSep10AuthResult` |
| `ui/components/Sep10AuthFlow.tsx` | Refactored to consume `useSep10Auth`; fixed `useMemo` import; fixed expired badge text |
| `ui/jest.config.js` | Added `<rootDir>/hooks` to `roots` so hook tests are discovered |