### PR TITLE
feat: add useRateLimitStatus hook with contract layer and full test coverage

### DIFF
--- a/ui/hooks/contractClient.ts
+++ b/ui/hooks/contractClient.ts
@@ -1,0 +1,77 @@
+/**
+ * Contract layer for AnchorKit's Soroban smart contract.
+ *
+ * Each function here maps to a read-only view on the on-chain contract.
+ * In production these would be wired to a Soroban RPC endpoint via
+ * @stellar/stellar-sdk (or a hosted serverless proxy).  The signatures are
+ * stable so callers and hooks can import the types without importing the SDK.
+ *
+ * Stellar ledger context
+ * ─────────────────────
+ * Stellar targets a ~5-second ledger close time.  The rate-limit window is
+ * measured in ledgers (e.g. 100 ledgers ≈ 8 minutes).  `RateLimitStatusRaw`
+ * carries both ledger numbers and the most-recent ledger's Unix timestamp so
+ * that callers can project wall-clock deadlines without a separate RPC round-
+ * trip.
+ */
+
+/** Raw values returned directly from the Soroban contract. */
+export interface RateLimitStatusRaw {
+  /** Submissions used in the current window (maps to `submission_count`). */
+  submissionCount: number;
+  /** Maximum submissions allowed per window (maps to `max_submissions`). */
+  maxSubmissions: number;
+  /** Ledger number when the current rate-limit window opened. */
+  windowStartLedger: number;
+  /** Window duration in ledgers (maps to `window_length`). */
+  windowLength: number;
+  /** Ledger sequence number at the time of the RPC call. */
+  currentLedger: number;
+  /**
+   * Unix timestamp (seconds) of the most-recently closed ledger.
+   * Used to project `windowResetsAt` into wall-clock time without an
+   * additional RPC call.
+   */
+  ledgerTimestamp: number;
+}
+
+/** Typed error thrown when the contract call fails. */
+export class ContractError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'ContractError';
+  }
+}
+
+/**
+ * Fetch the current rate-limit status for `attestor`.
+ *
+ * Combines `RateLimiter::get_state` and `RateLimiter::get_effective_config`
+ * from the Rust contract into a single typed response.
+ *
+ * @throws {ContractError} when the RPC call fails or `attestor` is unknown.
+ *
+ * Production wiring (not included — no SDK peer-dep in this package):
+ * ```ts
+ * import { Contract, rpc } from '@stellar/stellar-sdk';
+ * const server = new rpc.Server(process.env.STELLAR_RPC_URL);
+ * const contract = new Contract(process.env.CONTRACT_ID);
+ * const result = await server.simulateTransaction(
+ *   buildGetRateLimitStatusTx(contract, attestor)
+ * );
+ * return parseRateLimitStatusRaw(result);
+ * ```
+ */
+export async function getRateLimitStatus(
+  _attestor: string,
+): Promise<RateLimitStatusRaw> {
+  throw new ContractError(
+    'getRateLimitStatus: production contract client is not configured. ' +
+    'Wire this function to a Soroban RPC endpoint or inject a mock via the ' +
+    '`getStatus` option when using useRateLimitStatus.',
+    'NOT_CONFIGURED',
+  );
+}

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -13,3 +13,11 @@ export {
   type CopyToClipboardResult,
 } from './useCopyToClipboard';
 export { useTheme } from './useTheme';
+export {
+  useRateLimitStatus,
+  clearRateLimitCache,
+  type RateLimitStatus,
+  type UseRateLimitStatusResult,
+  type UseRateLimitStatusOptions,
+} from './useRateLimitStatus';
+export { type RateLimitStatusRaw, ContractError } from './contractClient';

--- a/ui/hooks/useRateLimitStatus.test.ts
+++ b/ui/hooks/useRateLimitStatus.test.ts
@@ -1,0 +1,544 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  useRateLimitStatus,
+  clearRateLimitCache,
+  type RateLimitStatus,
+} from './useRateLimitStatus';
+import type { RateLimitStatusRaw } from './contractClient';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ATTESTOR_A = 'GAFQKP7BFKHM3FGCXPZ3CIKWBEYK3KKFZM6RKWZD7M2BQTXTQNZQIZ';
+const ATTESTOR_B = 'GBZH7S5NC57XNHKHJ75C5DGMI3SP6VWAPQQKFPKZAKL7DW2FYW4XJKQ';
+
+const LEDGER_CLOSE_TIME_MS = 5_000;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRaw(overrides: Partial<RateLimitStatusRaw> = {}): RateLimitStatusRaw {
+  return {
+    submissionCount:  3,
+    maxSubmissions:   10,
+    windowStartLedger: 1_000,
+    windowLength:      100,
+    currentLedger:     1_050,   // 50 ledgers remain in the window
+    ledgerTimestamp:   Math.floor(Date.now() / 1_000),
+    ...overrides,
+  };
+}
+
+function mockGet(raw: RateLimitStatusRaw) {
+  return jest.fn<Promise<RateLimitStatusRaw>, [string]>().mockResolvedValue(raw);
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearRateLimitCache();
+  jest.clearAllMocks();
+});
+
+// ── Normal usage ──────────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – normal usage', () => {
+  it('returns status=null, loading=false, error=null on initial render', () => {
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(makeRaw()) }),
+    );
+    // Before the effect fires the hook has not started loading yet.
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets loading=true while the RPC call is in-flight', async () => {
+    let resolveRaw!: (r: RateLimitStatusRaw) => void;
+    const pending = new Promise<RateLimitStatusRaw>((r) => { resolveRaw = r; });
+    const getStatus = jest.fn().mockReturnValue(pending);
+
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.status).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    resolveRaw(makeRaw());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('populates status after a successful fetch', async () => {
+    const raw = makeRaw({ submissionCount: 4, maxSubmissions: 10 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    const { status } = result.current;
+    expect(status!.used).toBe(4);
+    expect(status!.limit).toBe(10);
+    expect(status!.isThrottled).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes windowResetsAt as a Date instance', async () => {
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(makeRaw()) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.windowResetsAt).toBeInstanceOf(Date);
+  });
+
+  it('computes windowResetsAt from ledger data', async () => {
+    const nowSec = Math.floor(Date.now() / 1_000);
+    // 50 ledgers remain → 50 × 5 s = 250 s from now
+    const raw = makeRaw({
+      windowStartLedger: 1_000,
+      windowLength:       100,
+      currentLedger:      1_050,
+      ledgerTimestamp:    nowSec,
+    });
+
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    const expected = nowSec * 1_000 + 50 * LEDGER_CLOSE_TIME_MS;
+    expect(result.current.status!.windowResetsAt.getTime()).toBe(expected);
+  });
+
+  it('clamps windowResetsAt to the ledger timestamp when the window has already expired', async () => {
+    const nowSec = Math.floor(Date.now() / 1_000);
+    // Window expired 10 ledgers ago → ledgersUntilReset = max(0, -10) = 0
+    const raw = makeRaw({
+      windowStartLedger: 1_000,
+      windowLength:       10,
+      currentLedger:      1_020,
+      ledgerTimestamp:    nowSec,
+    });
+
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.windowResetsAt.getTime()).toBe(nowSec * 1_000);
+  });
+
+  it('calls getStatus with the attestor address', async () => {
+    const getStatus = mockGet(makeRaw());
+    renderHook(() => useRateLimitStatus(ATTESTOR_A, { getStatus }));
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalledWith(ATTESTOR_A));
+  });
+});
+
+// ── Throttled state ───────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – throttled state', () => {
+  it('sets isThrottled=true when used === limit', async () => {
+    const raw = makeRaw({ submissionCount: 10, maxSubmissions: 10 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.isThrottled).toBe(true);
+    expect(result.current.status!.used).toBe(10);
+    expect(result.current.status!.limit).toBe(10);
+  });
+
+  it('sets isThrottled=true when used > limit (over-limit edge case)', async () => {
+    const raw = makeRaw({ submissionCount: 12, maxSubmissions: 10 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.isThrottled).toBe(true);
+  });
+
+  it('sets isThrottled=false when used < limit', async () => {
+    const raw = makeRaw({ submissionCount: 9, maxSubmissions: 10 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.isThrottled).toBe(false);
+  });
+
+  it('sets isThrottled=false when used is 0', async () => {
+    const raw = makeRaw({ submissionCount: 0, maxSubmissions: 10 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.isThrottled).toBe(false);
+  });
+
+  it('reflects the per-attestor limit, not just the global default', async () => {
+    // An attestor with a per-attestor override of 50 should not be throttled
+    // at the same point a default-10 attestor would be.
+    const raw = makeRaw({ submissionCount: 10, maxSubmissions: 50 });
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(raw) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.status!.isThrottled).toBe(false);
+    expect(result.current.status!.limit).toBe(50);
+  });
+});
+
+// ── Error scenarios ───────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – error scenarios', () => {
+  it('sets error and clears status when the RPC call rejects', async () => {
+    const getStatus = jest.fn().mockRejectedValue(new Error('RPC unavailable'));
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error!.message).toBe('RPC unavailable');
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('wraps non-Error rejection values in an Error', async () => {
+    const getStatus = jest.fn().mockRejectedValue('plain string rejection');
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error!.message).toBe('plain string rejection');
+  });
+
+  it('clears a previous error and status on subsequent failure', async () => {
+    const getStatus = jest.fn()
+      .mockRejectedValueOnce(new Error('first error'))
+      .mockRejectedValueOnce(new Error('second error'));
+
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe('first error'),
+    );
+
+    act(() => { result.current.refresh(); });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe('second error'),
+    );
+    expect(result.current.status).toBeNull();
+  });
+
+  // ── Missing / invalid attestor ──────────────────────────────────────────────
+
+  it('returns null status for a null attestor without calling getStatus', () => {
+    const getStatus = jest.fn();
+    const { result } = renderHook(() =>
+      useRateLimitStatus(null, { getStatus }),
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns null status for an undefined attestor without calling getStatus', () => {
+    const getStatus = jest.fn();
+    const { result } = renderHook(() =>
+      useRateLimitStatus(undefined, { getStatus }),
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns null status for an empty-string attestor without calling getStatus', () => {
+    const getStatus = jest.fn();
+    const { result } = renderHook(() =>
+      useRateLimitStatus('', { getStatus }),
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns null status for a whitespace-only attestor without calling getStatus', () => {
+    const getStatus = jest.fn();
+    const { result } = renderHook(() =>
+      useRateLimitStatus('   ', { getStatus }),
+    );
+
+    expect(result.current.status).toBeNull();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ── Attestor changes ──────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – attestor changes', () => {
+  it('re-fetches and calls getStatus with the new attestor when attestor changes', async () => {
+    const getStatus = jest.fn().mockResolvedValue(makeRaw());
+    let attestor = ATTESTOR_A;
+
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(attestor, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenLastCalledWith(ATTESTOR_A);
+
+    attestor = ATTESTOR_B;
+    rerender();
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
+    expect(getStatus).toHaveBeenLastCalledWith(ATTESTOR_B);
+  });
+
+  it('clears status and error immediately when attestor changes to null', async () => {
+    const getStatus = mockGet(makeRaw());
+    let attestor: string | null = ATTESTOR_A;
+
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(attestor, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    attestor = null;
+    rerender();
+
+    await waitFor(() => expect(result.current.status).toBeNull());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('clears a previous error when a valid attestor replaces null', async () => {
+    const getStatus = jest.fn().mockResolvedValue(makeRaw());
+    let attestor: string | null = null;
+
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(attestor, { getStatus }),
+    );
+
+    // Simulate an earlier error by manually checking initial state
+    expect(result.current.error).toBeNull();
+
+    attestor = ATTESTOR_A;
+    rerender();
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(result.current.error).toBeNull();
+  });
+});
+
+// ── Caching ───────────────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – caching', () => {
+  it('does not make a second RPC call for the same attestor within the TTL', async () => {
+    const getStatus = mockGet(makeRaw());
+    const options = { getStatus };
+
+    // First mount — populates the cache.
+    const { result: r1, unmount } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, options),
+    );
+    await waitFor(() => expect(r1.current.status).not.toBeNull());
+    unmount();
+
+    // Second mount — should hit the cache.
+    const { result: r2 } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, options),
+    );
+    await waitFor(() => expect(r2.current.status).not.toBeNull());
+
+    expect(getStatus).toHaveBeenCalledTimes(1); // only one RPC call
+  });
+
+  it('serves the cached value immediately (no loading flash) on a cache hit', async () => {
+    const getStatus = mockGet(makeRaw());
+    const options = { getStatus };
+
+    const { result: r1, unmount } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, options),
+    );
+    await waitFor(() => expect(r1.current.status).not.toBeNull());
+    unmount();
+
+    const { result: r2 } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, options),
+    );
+
+    // On a cache hit, loading should never become true.
+    expect(r2.current.loading).toBe(false);
+    await waitFor(() => expect(r2.current.status).not.toBeNull());
+    expect(r2.current.loading).toBe(false);
+  });
+
+  it('maintains separate cache entries for different attestors', async () => {
+    const rawA = makeRaw({ submissionCount: 2 });
+    const rawB = makeRaw({ submissionCount: 7 });
+
+    const getStatusA = mockGet(rawA);
+    const getStatusB = mockGet(rawB);
+
+    const { result: rA } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: getStatusA }),
+    );
+    const { result: rB } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_B, { getStatus: getStatusB }),
+    );
+
+    await waitFor(() => {
+      expect(rA.current.status?.used).toBe(2);
+      expect(rB.current.status?.used).toBe(7);
+    });
+  });
+
+  it('bypasses the cache and makes an RPC call on refresh()', async () => {
+    const getStatus = mockGet(makeRaw());
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    expect(getStatus).toHaveBeenCalledTimes(1);
+
+    act(() => { result.current.refresh(); });
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it('reflects updated data after refresh()', async () => {
+    const getStatus = jest.fn()
+      .mockResolvedValueOnce(makeRaw({ submissionCount: 3 }))
+      .mockResolvedValueOnce(makeRaw({ submissionCount: 8 }));
+
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.status?.used).toBe(3));
+
+    act(() => { result.current.refresh(); });
+
+    await waitFor(() => expect(result.current.status?.used).toBe(8));
+  });
+});
+
+// ── Stale request discard ─────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – stale request discard', () => {
+  it('discards the response from a superseded request when attestor changes mid-flight', async () => {
+    let resolveFirst!: (r: RateLimitStatusRaw) => void;
+    let resolveSecond!: (r: RateLimitStatusRaw) => void;
+
+    const getStatus = jest.fn()
+      .mockReturnValueOnce(
+        new Promise<RateLimitStatusRaw>((r) => { resolveFirst = r; }),
+      )
+      .mockReturnValueOnce(
+        new Promise<RateLimitStatusRaw>((r) => { resolveSecond = r; }),
+      );
+
+    let attestor = ATTESTOR_A;
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(attestor, { getStatus }),
+    );
+
+    // Switch attestor before the first response arrives.
+    attestor = ATTESTOR_B;
+    rerender();
+
+    // Resolve the second (current) request.
+    resolveSecond(makeRaw({ submissionCount: 7 }));
+    await waitFor(() => expect(result.current.status?.used).toBe(7));
+
+    // Resolve the stale first request — its result must be silently dropped.
+    resolveFirst(makeRaw({ submissionCount: 1 }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.status?.used).toBe(7); // unchanged
+  });
+
+  it('shows loading=true until the latest request settles, not the first one', async () => {
+    let resolveFirst!: (r: RateLimitStatusRaw) => void;
+    let resolveSecond!: (r: RateLimitStatusRaw) => void;
+
+    const getStatus = jest.fn()
+      .mockReturnValueOnce(
+        new Promise<RateLimitStatusRaw>((r) => { resolveFirst = r; }),
+      )
+      .mockReturnValueOnce(
+        new Promise<RateLimitStatusRaw>((r) => { resolveSecond = r; }),
+      );
+
+    let attestor = ATTESTOR_A;
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(attestor, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    attestor = ATTESTOR_B;
+    rerender();
+
+    // Resolve only the stale request — loading must still be true.
+    resolveFirst(makeRaw());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.loading).toBe(true);
+
+    // Resolve the current request — now loading can settle.
+    resolveSecond(makeRaw({ submissionCount: 5 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.status?.used).toBe(5);
+  });
+});
+
+// ── Typed-output shape ────────────────────────────────────────────────────────
+
+describe('useRateLimitStatus – returned shape', () => {
+  it('exposes a stable refresh function reference on re-render', async () => {
+    const getStatus = mockGet(makeRaw());
+    const { result, rerender } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+    const firstRefresh = result.current.refresh;
+
+    rerender();
+    expect(result.current.refresh).toBe(firstRefresh);
+  });
+
+  it('exposes all four fields on the status object', async () => {
+    const { result } = renderHook(() =>
+      useRateLimitStatus(ATTESTOR_A, { getStatus: mockGet(makeRaw()) }),
+    );
+
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    const s: RateLimitStatus = result.current.status!;
+    expect(typeof s.used).toBe('number');
+    expect(typeof s.limit).toBe('number');
+    expect(s.windowResetsAt).toBeInstanceOf(Date);
+    expect(typeof s.isThrottled).toBe('boolean');
+  });
+});

--- a/ui/hooks/useRateLimitStatus.ts
+++ b/ui/hooks/useRateLimitStatus.ts
@@ -1,0 +1,173 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  getRateLimitStatus as defaultGetStatus,
+  type RateLimitStatusRaw,
+} from './contractClient';
+
+/** Stellar's target ledger close time in milliseconds. */
+const LEDGER_CLOSE_TIME_MS = 5_000;
+
+/**
+ * How long a cached result is considered fresh.
+ * After this period the next render will trigger a new RPC call.
+ */
+const CACHE_TTL_MS = 30_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** UI-friendly rate-limit snapshot for a single attestor. */
+export interface RateLimitStatus {
+  /** Submissions consumed in the current window. */
+  used: number;
+  /** Maximum submissions allowed per window. */
+  limit: number;
+  /** Wall-clock time when the current window expires and the counter resets. */
+  windowResetsAt: Date;
+  /** `true` when `used >= limit` — the attestor cannot submit until the window resets. */
+  isThrottled: boolean;
+}
+
+export interface UseRateLimitStatusResult {
+  /** The latest rate-limit snapshot, or `null` before the first successful fetch. */
+  status: RateLimitStatus | null;
+  /** `true` while an RPC call is in-flight. */
+  loading: boolean;
+  /** The last fetch error, or `null` on success / before the first fetch. */
+  error: Error | null;
+  /**
+   * Bust the cache for the current attestor and re-fetch immediately.
+   * Useful for post-submission refreshes.
+   */
+  refresh: () => void;
+}
+
+type GetStatusFn = (attestor: string) => Promise<RateLimitStatusRaw>;
+
+export interface UseRateLimitStatusOptions {
+  /**
+   * Override the contract-layer function used to fetch rate-limit data.
+   * Primarily for testing; defaults to `getRateLimitStatus` from contractClient.
+   */
+  getStatus?: GetStatusFn;
+}
+
+// ── Module-level cache ────────────────────────────────────────────────────────
+// Keyed by attestor address.  Shared across hook instances to avoid duplicate
+// RPC calls when multiple components mount with the same attestor.
+
+const cache = new Map<string, { status: RateLimitStatus; fetchedAt: number }>();
+
+/** Clear the module-level cache.  Call in `afterEach` to isolate tests. */
+export function clearRateLimitCache(): void {
+  cache.clear();
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function computeStatus(raw: RateLimitStatusRaw): RateLimitStatus {
+  const used = raw.submissionCount;
+  const limit = raw.maxSubmissions;
+  const isThrottled = used >= limit;
+
+  // Ledgers remaining until the window closes (clamped to 0 when already expired).
+  const ledgersUntilReset = Math.max(
+    0,
+    raw.windowStartLedger + raw.windowLength - raw.currentLedger,
+  );
+
+  const windowResetsAt = new Date(
+    raw.ledgerTimestamp * 1_000 + ledgersUntilReset * LEDGER_CLOSE_TIME_MS,
+  );
+
+  return { used, limit, windowResetsAt, isThrottled };
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches and caches the rate-limit status for a single `attestor`.
+ *
+ * Behaviour contract:
+ * - Returns `{ status: null, loading: false, error: null }` immediately when
+ *   `attestor` is `null`, `undefined`, or an empty/whitespace string.
+ * - Sets `loading: true` for the duration of the RPC call.
+ * - Caches successful results for {@link CACHE_TTL_MS} ms; re-mounts with the
+ *   same attestor hit the cache and skip the network.
+ * - Re-fetches automatically when `attestor` changes.
+ * - Discards stale responses when a newer request arrives (race-safe).
+ * - Exposes `refresh()` to manually bust the cache and force a new fetch.
+ *
+ * @example
+ * ```tsx
+ * const { status, loading, error, refresh } = useRateLimitStatus(attestorAddress);
+ * if (status?.isThrottled) {
+ *   return <p>Rate limited — resets at {status.windowResetsAt.toLocaleTimeString()}</p>;
+ * }
+ * ```
+ */
+export function useRateLimitStatus(
+  attestor: string | null | undefined,
+  options?: UseRateLimitStatusOptions,
+): UseRateLimitStatusResult {
+  const [status, setStatus] = useState<RateLimitStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Monotonic counter used to discard responses from superseded requests.
+  const requestIdRef = useRef(0);
+
+  // Keep the getter in a ref so `fetchStatus` only re-creates when `attestor`
+  // changes, not when the caller passes a new `options` object each render.
+  const getStatusRef = useRef<GetStatusFn>(options?.getStatus ?? defaultGetStatus);
+  getStatusRef.current = options?.getStatus ?? defaultGetStatus;
+
+  const fetchStatus = useCallback(async () => {
+    if (!attestor || attestor.trim() === '') {
+      setStatus(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    // Return cached data if it is still fresh.
+    const cached = cache.get(attestor);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      setStatus(cached.status);
+      setError(null);
+      return;
+    }
+
+    const id = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const raw = await getStatusRef.current(attestor);
+      if (id !== requestIdRef.current) return; // stale — newer request superseded this one
+      const computed = computeStatus(raw);
+      cache.set(attestor, { status: computed, fetchedAt: Date.now() });
+      setStatus(computed);
+    } catch (err) {
+      if (id !== requestIdRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+      setStatus(null);
+    } finally {
+      if (id === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [attestor]); // attestor is the only real dependency; getStatus lives in a ref
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const refresh = useCallback(() => {
+    if (attestor) {
+      cache.delete(attestor); // evict so fetchStatus makes an RPC call
+    }
+    fetchStatus();
+  }, [attestor, fetchStatus]);
+
+  return { status, loading, error, refresh };
+}

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/components'],
+  roots: ['<rootDir>/components', '<rootDir>/hooks'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: [


### PR DESCRIPTION

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using "Closes #123" or "Fixes #123" format -->
Closes #693 


## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No tests required (documentation, CI/CD, etc.)

## Test Coverage
<!-- If applicable, mention test coverage changes -->
- [ ] Test coverage maintained or improved
- [ ] New tests added for new functionality

## Documentation
<!-- Mark the appropriate option with an "x" -->
- [ ] Documentation updated (if applicable)
- [ ] No documentation changes needed
- [ ] Documentation will be added in a follow-up PR

## Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
- [ ] No breaking changes
- [ ] Breaking changes (please describe):

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
