### PR TITLE
feat: add useAnchorHealth hook for live anchor health monitoring

### DIFF
--- a/ui/components/Sep10AuthFlow.tsx
+++ b/ui/components/Sep10AuthFlow.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useSep10Auth } from "../hooks/useSep10Auth";
 
 import './themes.css';
 
@@ -169,7 +170,6 @@ function TokenDisplay({ jwt }: { jwt: string }) {
   const [revealed, setRevealed] = useState(false);
   const parts = jwt.split(".");
   const colors = ["#ff7eb3", "#79d4fd", "#7effc7"];
-  const labels = ["HEADER", "PAYLOAD", "SIGNATURE"];
   const SENSITIVE_FIELDS = ["sub", "iss", "jti"];
 
   const copy = () => {
@@ -320,20 +320,18 @@ function TokenDisplay({ jwt }: { jwt: string }) {
 function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
   const [age, setAge] = useState(0);
   const [isExpired, setIsExpired] = useState(false);
-  
-  // Parse JWT to get expiry time
+
   const expiryTime = useMemo(() => {
     try {
       const parts = jwt.split(".");
       if (parts.length !== 3) return null;
       const payload = JSON.parse(atob(parts[1]));
-      return payload.exp ? payload.exp * 1000 : null; // Convert to milliseconds
+      return payload.exp ? payload.exp * 1000 : null;
     } catch {
       return null;
     }
   }, [jwt]);
 
-  // Poll token expiry every 30 seconds
   useEffect(() => {
     const checkExpiry = () => {
       if (!expiryTime) return;
@@ -345,13 +343,10 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
       }
     };
 
-    // Initial check
     checkExpiry();
 
-    // Poll every 30 seconds
     const intervalId = setInterval(checkExpiry, 30000);
 
-    // Also update age counter every second for display
     const ageIntervalId = setInterval(() => {
       if (!isExpired && expiryTime) {
         const now = Date.now();
@@ -372,11 +367,13 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
   const expiresIn = isExpired ? 0 : Math.max(0, 86400 - age);
   const pct = Math.max(0, (expiresIn / 86400) * 100);
 
-  // Determine status color based on expiry state
   const statusColor = isExpired ? "#ff3670" : expiresIn < 3600 ? "#ff8c00" : "#00ff9d";
   const statusBg = isExpired ? "rgba(255,54,112,0.06)" : expiresIn < 3600 ? "rgba(255,140,0,0.06)" : "rgba(0,255,157,0.06)";
   const statusBorder = isExpired ? "rgba(255,54,112,0.3)" : expiresIn < 3600 ? "rgba(255,140,0,0.3)" : "rgba(0,255,157,0.3)";
   const statusLabel = isExpired ? "EXPIRED" : "AUTHENTICATED";
+  const statusSubtext = isExpired
+    ? "Token has expired · Re-authenticate required"
+    : "Session active · SEP-10 verified";
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -416,7 +413,7 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
             {statusLabel}
           </div>
           <div style={{ fontSize: 10, color: "var(--ak-text-muted)", marginTop: 2 }}>
-            Session active · SEP-10 verified
+            {statusSubtext}
           </div>
         </div>
         <div style={{ textAlign: "right" }}>
@@ -465,9 +462,9 @@ function AuthStatusBadge({ wallet, jwt }: { wallet: WalletInfo; jwt: string }) {
               height: "100%",
               borderRadius: 2,
               width: `${pct}%`,
-              background: isExpired 
-                ? "linear-gradient(90deg,#ff3670,#ff3670)" 
-                : expiresIn < 3600 
+              background: isExpired
+                ? "linear-gradient(90deg,#ff3670,#ff3670)"
+                : expiresIn < 3600
                   ? "linear-gradient(90deg,#ff8c00,#ff8c00)"
                   : "linear-gradient(90deg,#00e5ff,#00ff9d)",
               boxShadow: `0 0 8px ${statusColor}60`,
@@ -529,9 +526,7 @@ export default function SEP10AuthFlow() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [challenge, setChallenge] = useState<string | null>(null);
   const [signedXdr, setSignedXdr] = useState<string | null>(null);
-  const [jwt, setJwt] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [domain, setDomain] = useState("testanchor.stellar.org");
   const [log, setLog] = useState<string[]>([]);
   const logRef = useRef<HTMLDivElement>(null);
@@ -545,6 +540,46 @@ export default function SEP10AuthFlow() {
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [log]);
+
+  // ── useSep10Auth ──────────────────────────────────────────────────────────
+  // Each adapter reflects the mock demo logic while also providing the values
+  // the hook needs to progress through the SEP-10 protocol.
+  const {
+    token: jwt,
+    isAuthenticated,
+    error: authError,
+    authenticate,
+    reset: resetAuth,
+  } = useSep10Auth(domain, {
+    // Returns the challenge XDR already fetched by the "Fetch Challenge" step.
+    fetchChallenge: async (_d: string, _addr: string): Promise<string> => {
+      if (!challenge) throw new Error("Challenge not yet fetched");
+      return challenge;
+    },
+    // Returns the signed XDR already produced by the "Sign Challenge" step.
+    signChallenge: async (_xdr: string): Promise<string> => {
+      if (!signedXdr) throw new Error("Challenge not yet signed");
+      return signedXdr;
+    },
+    // Submits to the anchor and receives the JWT. This is where the actual
+    // network call (or mock) lives — the only step not yet done by the UI.
+    submitChallenge: async (d: string, _signed: string): Promise<string> => {
+      addLog(`POST https://${d}/auth`);
+      addLog("Sending signed XDR...");
+      await sleep(700);
+      addLog("Response: 200 OK");
+      await sleep(300);
+      const token = mockJWT();
+      addLog("JWT received ✓");
+      addLog("Auth session established — expires in 24h");
+      return token;
+    },
+  });
+
+  // Transition to authenticated view once the hook sets the token.
+  useEffect(() => {
+    if (jwt) setStep("authenticated");
+  }, [jwt]);
 
   const NEON = "#00e5ff";
 
@@ -570,7 +605,6 @@ export default function SEP10AuthFlow() {
   // ── Step handlers ──
   const connectWallet = async () => {
     setLoading(true);
-    setError(null);
     addLog("Requesting wallet connection...");
     await sleep(900);
     addLog("Scanning for available wallets...");
@@ -586,7 +620,6 @@ export default function SEP10AuthFlow() {
 
   const fetchChallenge = async () => {
     setLoading(true);
-    setError(null);
     addLog(
       `GET https://${domain}/auth?account=${wallet?.address.slice(0, 8)}...`,
     );
@@ -602,7 +635,6 @@ export default function SEP10AuthFlow() {
 
   const signChallenge = async () => {
     setLoading(true);
-    setError(null);
     addLog("Sending challenge XDR to wallet for signing...");
     await sleep(800);
     addLog("User approved signature request");
@@ -614,19 +646,12 @@ export default function SEP10AuthFlow() {
     setLoading(false);
   };
 
+  // Delegates to useSep10Auth.authenticate() which runs the full SEP-10
+  // protocol using the adapters above (challenge and signedXdr already ready).
   const submitChallenge = async () => {
+    if (!wallet) return;
     setLoading(true);
-    setError(null);
-    addLog(`POST https://${domain}/auth`);
-    addLog("Sending signed XDR...");
-    await sleep(700);
-    addLog("Response: 200 OK");
-    await sleep(300);
-    const token = mockJWT();
-    addLog("JWT received ✓");
-    addLog("Auth session established — expires in 24h");
-    setJwt(token);
-    setStep("authenticated");
+    await authenticate(wallet.address);
     setLoading(false);
   };
 
@@ -635,8 +660,7 @@ export default function SEP10AuthFlow() {
     setWallet(null);
     setChallenge(null);
     setSignedXdr(null);
-    setJwt(null);
-    setError(null);
+    resetAuth();
     addLog("─── Session reset ───");
   };
 
@@ -897,6 +921,11 @@ export default function SEP10AuthFlow() {
             <code style={{ color: "#79d4fd", fontSize: 10 }}>Bearer</code> token
             in all subsequent SEP requests.
           </p>
+          {authError && (
+            <p style={{ fontSize: 10, color: "#ff3670", marginBottom: 12 }}>
+              {authError}
+            </p>
+          )}
           <button
             onClick={submitChallenge}
             disabled={loading || !signedXdr}
@@ -1351,7 +1380,7 @@ export default function SEP10AuthFlow() {
         </div>
 
         {/* ── Auth Status (full width, post-auth) ── */}
-        {step === "authenticated" && wallet && (
+        {step === "authenticated" && wallet && jwt && (
           <div
             style={{
               borderRadius: 12,

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -15,3 +15,5 @@ export {
 export { useTheme } from './useTheme';
 export { useSep10Auth } from './useSep10Auth';
 export type { Sep10AuthAdapters, UseSep10AuthResult } from './useSep10Auth';
+export { useAnchorHealth, isValidAttestor } from './useAnchorHealth';
+export type { GetHealthScoreFn, UseAnchorHealthResult } from './useAnchorHealth';

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -13,3 +13,5 @@ export {
   type CopyToClipboardResult,
 } from './useCopyToClipboard';
 export { useTheme } from './useTheme';
+export { useSep10Auth } from './useSep10Auth';
+export type { Sep10AuthAdapters, UseSep10AuthResult } from './useSep10Auth';

--- a/ui/hooks/useAnchorHealth.test.ts
+++ b/ui/hooks/useAnchorHealth.test.ts
@@ -1,0 +1,667 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAnchorHealth, isValidAttestor, GetHealthScoreFn } from './useAnchorHealth';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ATTESTOR = 'G' + 'A'.repeat(55);
+const CONTRACT = 'C' + 'A'.repeat(55);
+const INTERVAL = 5_000;
+
+function makeGetHealthScore(score = 85): jest.MockedFunction<GetHealthScoreFn> {
+  return jest.fn().mockResolvedValue(score);
+}
+
+// ── isValidAttestor ────────────────────────────────────────────────────────────
+
+describe('isValidAttestor', () => {
+  test('accepts a valid ed25519 G-address', () => {
+    expect(isValidAttestor(ATTESTOR)).toBe(true);
+  });
+
+  test('accepts a valid contract C-address', () => {
+    expect(isValidAttestor(CONTRACT)).toBe(true);
+  });
+
+  test('rejects null', () => {
+    expect(isValidAttestor(null)).toBe(false);
+  });
+
+  test('rejects undefined', () => {
+    expect(isValidAttestor(undefined)).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(isValidAttestor('')).toBe(false);
+  });
+
+  test('rejects wrong starting character', () => {
+    expect(isValidAttestor('A' + 'A'.repeat(55))).toBe(false);
+  });
+
+  test('rejects address that is too short', () => {
+    expect(isValidAttestor('G' + 'A'.repeat(54))).toBe(false);
+  });
+
+  test('rejects address that is too long', () => {
+    expect(isValidAttestor('G' + 'A'.repeat(56))).toBe(false);
+  });
+
+  test('rejects address with invalid base32 characters', () => {
+    expect(isValidAttestor('G' + '0'.repeat(55))).toBe(false); // '0' invalid in base32
+  });
+});
+
+// ── Initial state ──────────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — initial state', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('null attestor: all fields are idle (no loading, no score)', () => {
+    const { result } = renderHook(() =>
+      useAnchorHealth(null, INTERVAL, makeGetHealthScore()),
+    );
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeNull();
+  });
+
+  test('undefined attestor: all fields are idle', () => {
+    const { result } = renderHook(() =>
+      useAnchorHealth(undefined, INTERVAL, makeGetHealthScore()),
+    );
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeNull();
+  });
+
+  test('invalid attestor: all fields are idle', () => {
+    const { result } = renderHook(() =>
+      useAnchorHealth('not-an-address', INTERVAL, makeGetHealthScore()),
+    );
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeNull();
+  });
+
+  test('valid attestor: loading is true before first poll completes', () => {
+    // Hold the mock unresolved so the initial fetch is still in-flight.
+    const mockFn = jest.fn().mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+    expect(result.current.loading).toBe(true);
+    expect(result.current.score).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  test('no polling starts when attestor is absent', () => {
+    const mockFn = makeGetHealthScore();
+    renderHook(() => useAnchorHealth(null, INTERVAL, mockFn));
+    act(() => jest.advanceTimersByTime(INTERVAL * 5));
+    expect(mockFn).not.toHaveBeenCalled();
+  });
+});
+
+// ── Successful polling ─────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — successful polling', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('first poll resolves: loading→false, score set, lastUpdated set', async () => {
+    const mockFn = makeGetHealthScore(72);
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.score).toBe(72);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  test('getHealthScore is called with the attestor address', async () => {
+    const mockFn = makeGetHealthScore(50);
+    renderHook(() => useAnchorHealth(ATTESTOR, INTERVAL, mockFn));
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledWith(ATTESTOR);
+  });
+
+  test('getHealthScore is called with a contract C-address', async () => {
+    const mockFn = makeGetHealthScore(90);
+    renderHook(() => useAnchorHealth(CONTRACT, INTERVAL, mockFn));
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockFn).toHaveBeenCalledWith(CONTRACT);
+  });
+
+  test('score 0 is stored correctly (not treated as falsy)', async () => {
+    const mockFn = makeGetHealthScore(0);
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.score).toBe(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('score 100 is stored correctly', async () => {
+    const mockFn = makeGetHealthScore(100);
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.score).toBe(100);
+  });
+});
+
+// ── Score updates ──────────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — score updates on subsequent polls', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('second poll updates the score', async () => {
+    const mockFn = jest.fn()
+      .mockResolvedValueOnce(60)
+      .mockResolvedValueOnce(75);
+
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(60);
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(result.current.score).toBe(75);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  test('lastUpdated advances with each successful poll', async () => {
+    const times: Date[] = [];
+    const mockFn = jest.fn().mockImplementation(() => {
+      times.push(new Date());
+      return Promise.resolve(50);
+    });
+
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    const first = result.current.lastUpdated!;
+
+    // Advance real time inside fake-timer world by making the mock capture
+    // a later Date on the second call.
+    jest.setSystemTime(jest.getRealSystemTime() + INTERVAL);
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    const second = result.current.lastUpdated!;
+    expect(second.getTime()).toBeGreaterThanOrEqual(first.getTime());
+  });
+
+  test('loading stays false during background polls after initial load', async () => {
+    const mockFn = makeGetHealthScore(80);
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('polls fire at the requested interval', async () => {
+    const mockFn = makeGetHealthScore(88);
+    renderHook(() => useAnchorHealth(ATTESTOR, INTERVAL, mockFn));
+
+    // Flush initial poll
+    await act(async () => { await Promise.resolve(); });
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    // Three more ticks
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(INTERVAL);
+        await Promise.resolve();
+      });
+    }
+
+    expect(mockFn).toHaveBeenCalledTimes(4);
+  });
+});
+
+// ── Error handling ─────────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — error handling', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('initial poll failure: error set, loading false, score null', async () => {
+    const mockFn = jest.fn().mockRejectedValue(new Error('Contract call failed'));
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.score).toBeNull();
+    expect(result.current.error).toBe('Contract call failed');
+    expect(result.current.lastUpdated).toBeNull();
+  });
+
+  test('non-Error rejection produces a generic fallback message', async () => {
+    const mockFn = jest.fn().mockRejectedValue('string error');
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.error).toBe(
+      'Failed to fetch health score. Please try again.',
+    );
+  });
+
+  test('subsequent poll failure keeps the last known score alongside the error', async () => {
+    const mockFn = jest.fn()
+      .mockResolvedValueOnce(65)
+      .mockRejectedValueOnce(new Error('Network timeout'));
+
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(65);
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(result.current.score).toBe(65);       // stale score preserved
+    expect(result.current.error).toBe('Network timeout');
+  });
+
+  test('successful poll after an error clears the error', async () => {
+    const mockFn = jest.fn()
+      .mockRejectedValueOnce(new Error('Timeout'))
+      .mockResolvedValueOnce(90);
+
+    const { result } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.error).toBe('Timeout');
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(result.current.score).toBe(90);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('error is cleared when attestor changes to a new valid address', async () => {
+    const mockFn = jest.fn()
+      .mockRejectedValueOnce(new Error('Bad attestor'))
+      .mockResolvedValue(55);
+
+    const { result, rerender } = renderHook(
+      ({ a }: { a: string }) => useAnchorHealth(a, INTERVAL, mockFn),
+      { initialProps: { a: ATTESTOR } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.error).toBe('Bad attestor');
+
+    const OTHER = 'G' + 'B'.repeat(55);
+    rerender({ a: OTHER });
+    expect(result.current.error).toBeNull();
+    expect(result.current.score).toBeNull();
+  });
+});
+
+// ── Interval changes ───────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — interval changes', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('shortening the interval causes polling to fire more frequently', async () => {
+    const mockFn = makeGetHealthScore(77);
+    const { rerender } = renderHook(
+      ({ iv }: { iv: number }) => useAnchorHealth(ATTESTOR, iv, mockFn),
+      { initialProps: { iv: 10_000 } },
+    );
+
+    // Flush initial poll
+    await act(async () => { await Promise.resolve(); });
+
+    // Switch to faster interval — this triggers an immediate re-poll too
+    rerender({ iv: 1_000 });
+    await act(async () => { await Promise.resolve(); });
+    const callsAfterRerender = mockFn.mock.calls.length; // initial + immediate re-poll
+
+    // Advance 3 separate ticks, flushing async promises after each so
+    // in-flight deduplication does not suppress subsequent ticks.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1_000);
+        await Promise.resolve();
+      });
+    }
+
+    expect(mockFn.mock.calls.length).toBe(callsAfterRerender + 3);
+  });
+
+  test('changing interval restarts the timer (old interval no longer fires)', async () => {
+    const mockFn = makeGetHealthScore(55);
+    const { rerender } = renderHook(
+      ({ iv }: { iv: number }) => useAnchorHealth(ATTESTOR, iv, mockFn),
+      { initialProps: { iv: 10_000 } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+
+    // Switch to a much longer interval; flush the immediate re-poll that
+    // fires when the effect restarts.
+    rerender({ iv: 30_000 });
+    await act(async () => { await Promise.resolve(); });
+    const callsAfterRerender = mockFn.mock.calls.length;
+
+    // Advance 10 000 ms — the OLD 10 s timer would have fired here, but it
+    // was cancelled.  The new 30 s timer has not fired yet.
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    expect(mockFn.mock.calls.length).toBe(callsAfterRerender);
+  });
+
+  test('existing score is preserved when only the interval changes', async () => {
+    const mockFn = makeGetHealthScore(63);
+    const { result, rerender } = renderHook(
+      ({ iv }: { iv: number }) => useAnchorHealth(ATTESTOR, iv, mockFn),
+      { initialProps: { iv: 5_000 } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(63);
+
+    rerender({ iv: 10_000 });
+
+    // Score should be preserved immediately after interval change
+    expect(result.current.score).toBe(63);
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+// ── Attestor changes ───────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — attestor changes', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('changing attestor resets score to null and sets loading true', async () => {
+    const mockFn = makeGetHealthScore(70);
+    const { result, rerender } = renderHook(
+      ({ a }: { a: string }) => useAnchorHealth(a, INTERVAL, mockFn),
+      { initialProps: { a: ATTESTOR } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(70);
+
+    const OTHER = 'G' + 'B'.repeat(55);
+    rerender({ a: OTHER });
+
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  test('new attestor is used in subsequent polls', async () => {
+    const mockFn = makeGetHealthScore(80);
+    const OTHER = 'G' + 'B'.repeat(55);
+
+    const { rerender } = renderHook(
+      ({ a }: { a: string }) => useAnchorHealth(a, INTERVAL, mockFn),
+      { initialProps: { a: ATTESTOR } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(mockFn).toHaveBeenLastCalledWith(ATTESTOR);
+
+    rerender({ a: OTHER });
+    await act(async () => { await Promise.resolve(); });
+    expect(mockFn).toHaveBeenLastCalledWith(OTHER);
+  });
+
+  test('switching to null attestor stops polling and resets state', async () => {
+    const mockFn = makeGetHealthScore(90);
+    const { result, rerender } = renderHook(
+      ({ a }: { a: string | null }) => useAnchorHealth(a, INTERVAL, mockFn),
+      { initialProps: { a: ATTESTOR as string | null } },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(90);
+
+    rerender({ a: null });
+
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    const callsBefore = mockFn.mock.calls.length;
+    act(() => jest.advanceTimersByTime(INTERVAL * 3));
+    expect(mockFn.mock.calls.length).toBe(callsBefore); // no new calls
+  });
+
+  test('switching from invalid to valid attestor starts polling', async () => {
+    const mockFn = makeGetHealthScore(45);
+    const { result, rerender } = renderHook(
+      ({ a }: { a: string | null }) => useAnchorHealth(a, INTERVAL, mockFn),
+      { initialProps: { a: null as string | null } },
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(mockFn).not.toHaveBeenCalled();
+
+    rerender({ a: ATTESTOR });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(45);
+  });
+});
+
+// ── Cleanup behaviour ──────────────────────────────────────────────────────────
+
+describe('useAnchorHealth — cleanup behaviour', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('unmount cancels the polling interval', async () => {
+    const mockFn = makeGetHealthScore(50);
+    const { unmount } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    const callsAtUnmount = mockFn.mock.calls.length;
+
+    unmount();
+
+    act(() => jest.advanceTimersByTime(INTERVAL * 5));
+    expect(mockFn.mock.calls.length).toBe(callsAtUnmount); // no new calls
+  });
+
+  test('in-flight request on unmount does not update state', async () => {
+    let resolveHealth!: (v: number) => void;
+    const mockFn = jest.fn().mockReturnValue(
+      new Promise<number>((r) => { resolveHealth = r; }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, mockFn),
+    );
+
+    // loading=true, poll in-flight (not yet resolved)
+    expect(result.current.loading).toBe(true);
+
+    // Unmount while poll is still pending
+    act(() => unmount());
+
+    // Now resolve the in-flight request — should be a no-op
+    await act(async () => {
+      resolveHealth(99);
+      await Promise.resolve();
+    });
+
+    // State should not have been updated after unmount
+    expect(result.current.score).toBeNull();
+    expect(result.current.loading).toBe(true); // last rendered value — unchanged
+  });
+
+  test('no interval is leaked: clearing all timers after unmount shows no pending timers', () => {
+    const { unmount } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, makeGetHealthScore()),
+    );
+    unmount();
+    // jest.runOnlyPendingTimers() should not throw or call the mock
+    expect(() => act(() => jest.runOnlyPendingTimers())).not.toThrow();
+  });
+});
+
+// ── Overlapping request prevention ────────────────────────────────────────────
+
+describe('useAnchorHealth — overlapping request prevention', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('timer firing while a poll is in-flight is silently skipped', async () => {
+    // First call hangs; second call resolves immediately.
+    let resolveFirst!: (v: number) => void;
+    const mockFn = jest.fn()
+      .mockReturnValueOnce(new Promise<number>((r) => { resolveFirst = r; }))
+      .mockResolvedValue(42);
+
+    renderHook(() => useAnchorHealth(ATTESTOR, INTERVAL, mockFn));
+
+    // Initial poll is in-flight (unresolved).
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    // Timer fires while first poll is still pending — should be skipped.
+    act(() => jest.advanceTimersByTime(INTERVAL));
+    expect(mockFn).toHaveBeenCalledTimes(1); // no second call yet
+
+    // Resolve first poll, then let the next tick run normally.
+    await act(async () => {
+      resolveFirst(37);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(mockFn).toHaveBeenCalledTimes(2); // second call allowed once first finished
+  });
+});
+
+// ── Adapter reference stability ────────────────────────────────────────────────
+
+describe('useAnchorHealth — adapter reference stability', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
+
+  test('passing a new inline function reference on each render does not restart the timer', async () => {
+    let renderCount = 0;
+    const innerFn = makeGetHealthScore(33);
+
+    const { result, rerender } = renderHook(() => {
+      renderCount++;
+      // Fresh arrow function every render — timer must not restart
+      return useAnchorHealth(ATTESTOR, INTERVAL, () => innerFn(ATTESTOR));
+    });
+
+    await act(async () => { await Promise.resolve(); });
+    const callsAfterInit = innerFn.mock.calls.length;
+
+    // Force extra renders without changing deps
+    rerender();
+    rerender();
+
+    // Advancing time by less than one interval: no extra calls expected
+    act(() => jest.advanceTimersByTime(INTERVAL - 1));
+    expect(innerFn.mock.calls.length).toBe(callsAfterInit);
+  });
+
+  test('the most recent getHealthScore function is used on each tick', async () => {
+    const v1 = jest.fn().mockResolvedValue(10);
+    const v2 = jest.fn().mockResolvedValue(20);
+    let currentFn: GetHealthScoreFn = v1;
+
+    const { result, rerender } = renderHook(() =>
+      useAnchorHealth(ATTESTOR, INTERVAL, currentFn),
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.score).toBe(10);
+
+    // Swap the implementation
+    currentFn = v2;
+    rerender();
+
+    await act(async () => {
+      jest.advanceTimersByTime(INTERVAL);
+      await Promise.resolve();
+    });
+
+    expect(result.current.score).toBe(20);
+    expect(v2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/hooks/useAnchorHealth.ts
+++ b/ui/hooks/useAnchorHealth.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useRef } from 'react';
+
+// ── Public types ───────────────────────────────────────────────────────────────
+
+/** Contract call signature for fetching the on-chain health score. */
+export type GetHealthScoreFn = (attestor: string) => Promise<number>;
+
+export interface UseAnchorHealthResult {
+  /** Latest health score (0–100), or null before the first successful poll. */
+  score: number | null;
+  /** True only during the initial fetch before any score or error has arrived. */
+  loading: boolean;
+  /** User-friendly message from the most recent failed poll; null when healthy. */
+  error: string | null;
+  /** Timestamp of the most recent successful score fetch; null until first success. */
+  lastUpdated: Date | null;
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────────
+
+/** Accepts 56-char Stellar StrKey starting with G (ed25519) or C (contract). */
+export function isValidAttestor(addr: string | null | undefined): addr is string {
+  if (!addr) return false;
+  return /^[GC][A-Z2-7]{55}$/.test(addr);
+}
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Polls `get_anchor_health_score` at `interval` milliseconds via the supplied
+ * `getHealthScore` adapter and returns live health data.
+ *
+ * Design notes:
+ * - `getHealthScore` is held in a ref so callers can pass inline functions
+ *   without restarting the timer on every render.
+ * - Overlapping requests are skipped: if the previous poll is still in-flight
+ *   when the interval fires, the new tick is a no-op.
+ * - When `attestor` changes the timer is cancelled, all state is reset, and a
+ *   fresh polling cycle begins.  When only `interval` changes the timer is
+ *   restarted but state is NOT reset (the latest score remains visible).
+ * - `loading` is only `true` during the very first fetch after mounting or
+ *   after the attestor changes; background polls run silently.
+ */
+export function useAnchorHealth(
+  attestor: string | null | undefined,
+  interval: number,
+  getHealthScore: GetHealthScoreFn,
+): UseAnchorHealthResult {
+  const [score, setScore] = useState<number | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  // Keeps the latest function reference without adding it to effect deps,
+  // preventing timer restarts when the caller passes a new inline function.
+  const getHealthScoreRef = useRef<GetHealthScoreFn>(getHealthScore);
+  getHealthScoreRef.current = getHealthScore;
+
+  // Track previous attestor so we can distinguish "attestor changed" from
+  // "only interval changed" and avoid resetting visible state unnecessarily.
+  const prevAttestorRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    const attestorChanged = prevAttestorRef.current !== attestor;
+    prevAttestorRef.current = attestor;
+
+    if (!isValidAttestor(attestor)) {
+      if (attestorChanged) {
+        setScore(null);
+        setLastUpdated(null);
+        setError(null);
+        setLoading(false);
+      }
+      return;
+    }
+
+    // Reset state for a new attestor; preserve it for an interval-only change.
+    if (attestorChanged) {
+      setScore(null);
+      setLastUpdated(null);
+      setError(null);
+      setLoading(true);
+    }
+
+    let cancelled = false;
+    // Per-closure in-flight flag prevents overlapping requests.
+    let inFlight = false;
+
+    const poll = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const newScore = await getHealthScoreRef.current(attestor);
+        if (!cancelled) {
+          setScore(newScore);
+          setLastUpdated(new Date());
+          setError(null);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'Failed to fetch health score. Please try again.',
+          );
+          setLoading(false);
+        }
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    poll();
+    const timerId = setInterval(poll, interval);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timerId);
+    };
+  }, [attestor, interval]); // getHealthScore intentionally excluded — kept in ref
+
+  return { score, loading, error, lastUpdated };
+}

--- a/ui/hooks/useSep10Auth.test.ts
+++ b/ui/hooks/useSep10Auth.test.ts
@@ -1,0 +1,439 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSep10Auth, Sep10AuthAdapters } from './useSep10Auth';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const DOMAIN = 'testanchor.stellar.org';
+const ADDRESS = 'G' + 'A'.repeat(55);
+const CHALLENGE_XDR = 'AAAAAGL8HQv_challenge_base64==';
+const SIGNED_XDR = 'AAAAAGL8HQv_signed_base64==';
+const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.signature';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAdapters(overrides?: Partial<Sep10AuthAdapters>): Sep10AuthAdapters {
+  return {
+    fetchChallenge: jest.fn().mockResolvedValue(CHALLENGE_XDR),
+    signChallenge: jest.fn().mockResolvedValue(SIGNED_XDR),
+    submitChallenge: jest.fn().mockResolvedValue(JWT),
+    ...overrides,
+  };
+}
+
+// ── Successful authentication ─────────────────────────────────────────────────
+
+describe('useSep10Auth — successful authentication', () => {
+  test('initial state: not authenticated, not loading, no error, no token', () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAuthenticating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('authenticate() runs full flow: fetchChallenge → signChallenge → submitChallenge', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith(DOMAIN, ADDRESS);
+    expect(adapters.signChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.signChallenge).toHaveBeenCalledWith(CHALLENGE_XDR);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(1);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith(DOMAIN, SIGNED_XDR);
+  });
+
+  test('token is set after successful authenticate()', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('isAuthenticating is true during the flow, false after', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // Start authenticate (don't await yet)
+    act(() => { result.current.authenticate(ADDRESS); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(false));
+    expect(result.current.token).toBe(JWT);
+  });
+
+  test('token persists in state after authenticate() resolves', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    // Simulate a re-render (ref should still have the token)
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('passes the correct domain from anchorDomain parameter', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth('custom.anchor.com', adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith('custom.anchor.com', ADDRESS);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith('custom.anchor.com', SIGNED_XDR);
+  });
+
+  test('uses the latest domain when anchorDomain changes between renders', async () => {
+    const adapters = makeAdapters();
+    const { result, rerender } = renderHook(
+      ({ domain }: { domain: string }) => useSep10Auth(domain, adapters),
+      { initialProps: { domain: 'old.anchor.com' } }
+    );
+
+    rerender({ domain: 'new.anchor.com' });
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(adapters.fetchChallenge).toHaveBeenCalledWith('new.anchor.com', ADDRESS);
+    expect(adapters.submitChallenge).toHaveBeenCalledWith('new.anchor.com', SIGNED_XDR);
+  });
+});
+
+// ── Failed authentication ─────────────────────────────────────────────────────
+
+describe('useSep10Auth — failed authentication', () => {
+  test('sets error when fetchChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue(new Error('Network timeout')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Network timeout');
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(adapters.signChallenge).not.toHaveBeenCalled();
+    expect(adapters.submitChallenge).not.toHaveBeenCalled();
+  });
+
+  test('sets error when signChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      signChallenge: jest.fn().mockRejectedValue(new Error('User rejected signing')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('User rejected signing');
+    expect(result.current.token).toBeNull();
+    expect(adapters.submitChallenge).not.toHaveBeenCalled();
+  });
+
+  test('sets error when submitChallenge rejects', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('Invalid signature')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Invalid signature');
+    expect(result.current.token).toBeNull();
+  });
+
+  test('wraps non-Error rejections in a generic message', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue('timeout'),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.error).toBe('Authentication failed. Please try again.');
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticating is false after a failed authenticate()', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('server error')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    expect(result.current.isAuthenticating).toBe(false);
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — error handling', () => {
+  test('error is cleared at the start of the next authenticate() call', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn()
+        .mockRejectedValueOnce(new Error('first failure'))
+        .mockResolvedValue(CHALLENGE_XDR),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // First call fails
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).toBe('first failure');
+
+    // Second call clears error before running
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.token).toBe(JWT);
+  });
+
+  test('retrying after an error sets the token on success', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn()
+        .mockRejectedValueOnce(new Error('anchor unavailable'))
+        .mockResolvedValue(JWT),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+    expect(result.current.token).toBe(JWT);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+// ── Deduplication ─────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — deduplication', () => {
+  test('concurrent calls to authenticate() are deduplicated to one network flow', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    // Fire two concurrent authenticate calls before the first resolves
+    act(() => {
+      result.current.authenticate(ADDRESS);
+      result.current.authenticate(ADDRESS);
+    });
+
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+
+    await waitFor(() => expect(result.current.token).toBe(JWT));
+
+    // Only one fetchChallenge request despite two authenticate() calls
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  test('calling authenticate() while isAuthenticating returns immediately', async () => {
+    let resolveSubmit!: (v: string) => void;
+    const slowSubmit = new Promise<string>(r => { resolveSubmit = r; });
+    const adapters = makeAdapters({ submitChallenge: jest.fn().mockReturnValue(slowSubmit) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    act(() => { result.current.authenticate(ADDRESS); });
+
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+    const callsBefore = (adapters.fetchChallenge as jest.Mock).mock.calls.length;
+
+    // Second call while first is in-flight
+    await act(async () => {
+      await result.current.authenticate(ADDRESS);
+    });
+
+    // No additional fetchChallenge call
+    expect(adapters.fetchChallenge).toHaveBeenCalledTimes(callsBefore);
+
+    // Resolve the original and verify single token set
+    act(() => { resolveSubmit(JWT); });
+    await waitFor(() => expect(result.current.token).toBe(JWT));
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  test('authenticate() can be called again after a previous call completes', async () => {
+    const jwt2 = 'second.jwt.token';
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn()
+        .mockResolvedValueOnce(JWT)
+        .mockResolvedValueOnce(jwt2),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(jwt2);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+describe('useSep10Auth — reset', () => {
+  test('reset() clears the token', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+
+    act(() => { result.current.reset(); });
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('reset() clears the error', async () => {
+    const adapters = makeAdapters({
+      fetchChallenge: jest.fn().mockRejectedValue(new Error('some error')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.error).not.toBeNull();
+
+    act(() => { result.current.reset(); });
+    expect(result.current.error).toBeNull();
+  });
+
+  test('reset() clears isAuthenticating', async () => {
+    let resolveChallenge!: (v: string) => void;
+    const slowChallenge = new Promise<string>(r => { resolveChallenge = r; });
+    const adapters = makeAdapters({ fetchChallenge: jest.fn().mockReturnValue(slowChallenge) });
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    act(() => { result.current.authenticate(ADDRESS); });
+    await waitFor(() => expect(result.current.isAuthenticating).toBe(true));
+
+    act(() => { result.current.reset(); });
+    expect(result.current.isAuthenticating).toBe(false);
+
+    // Resolve the pending promise — no state update should occur (in-flight guard cleared)
+    act(() => { resolveChallenge(CHALLENGE_XDR); });
+  });
+
+  test('authenticate() works after reset()', async () => {
+    const adapters = makeAdapters();
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    act(() => { result.current.reset(); });
+    expect(result.current.token).toBeNull();
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.token).toBe(JWT);
+    expect(adapters.submitChallenge).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Adapter reference stability ───────────────────────────────────────────────
+
+describe('useSep10Auth — adapter reference stability', () => {
+  test('uses the latest adapter functions when authenticate() runs', async () => {
+    const fetchV1 = jest.fn().mockResolvedValue(CHALLENGE_XDR);
+    const fetchV2 = jest.fn().mockResolvedValue('updated_challenge==');
+
+    const { result, rerender } = renderHook(
+      ({ adapters }: { adapters: Sep10AuthAdapters }) => useSep10Auth(DOMAIN, adapters),
+      { initialProps: { adapters: makeAdapters({ fetchChallenge: fetchV1 }) } }
+    );
+
+    // Swap the adapter before calling authenticate
+    rerender({ adapters: makeAdapters({ fetchChallenge: fetchV2 }) });
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+
+    // Should have called the updated adapter
+    expect(fetchV2).toHaveBeenCalledTimes(1);
+    expect(fetchV1).not.toHaveBeenCalled();
+  });
+
+  test('inline adapter functions do not cause the effect to restart', async () => {
+    const callLog: string[] = [];
+    const adapters: Sep10AuthAdapters = {
+      fetchChallenge: jest.fn(async () => { callLog.push('fetch'); return CHALLENGE_XDR; }),
+      signChallenge: jest.fn(async () => { callLog.push('sign'); return SIGNED_XDR; }),
+      submitChallenge: jest.fn(async () => { callLog.push('submit'); return JWT; }),
+    };
+
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+
+    // Each step is called exactly once
+    expect(callLog).toEqual(['fetch', 'sign', 'submit']);
+  });
+});
+
+// ── isAuthenticated derivation ────────────────────────────────────────────────
+
+describe('useSep10Auth — isAuthenticated', () => {
+  test('isAuthenticated is false before authenticate()', () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticated is true immediately after token is set', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('isAuthenticated is false after reset()', async () => {
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, makeAdapters()));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    act(() => { result.current.reset(); });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('isAuthenticated is false after a failed authenticate()', async () => {
+    const adapters = makeAdapters({
+      submitChallenge: jest.fn().mockRejectedValue(new Error('fail')),
+    });
+    const { result } = renderHook(() => useSep10Auth(DOMAIN, adapters));
+    await act(async () => { await result.current.authenticate(ADDRESS); });
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});

--- a/ui/hooks/useSep10Auth.ts
+++ b/ui/hooks/useSep10Auth.ts
@@ -1,0 +1,99 @@
+import { useState, useRef, useCallback } from 'react';
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/**
+ * Injectable adapters for each step of the SEP-10 challenge-response protocol.
+ * Keeping these injectable decouples the hook from any specific transport or
+ * wallet library and makes the hook straightforward to unit-test.
+ */
+export interface Sep10AuthAdapters {
+  /** GET /{domain}/auth?account={address} → base64-encoded challenge XDR */
+  fetchChallenge: (domain: string, walletAddress: string) => Promise<string>;
+  /** Sign the challenge XDR with the wallet private key → signed XDR */
+  signChallenge: (challengeXdr: string) => Promise<string>;
+  /** POST /{domain}/auth with signed XDR → JWT bearer token */
+  submitChallenge: (domain: string, signedXdr: string) => Promise<string>;
+}
+
+export interface UseSep10AuthResult {
+  /** JWT bearer token, or null before successful authentication */
+  token: string | null;
+  /** True when token is non-null (derived — does not check expiry) */
+  isAuthenticated: boolean;
+  /** True while authenticate() is running */
+  isAuthenticating: boolean;
+  /** User-friendly error from the most recent failed authenticate() call */
+  error: string | null;
+  /**
+   * Executes the full SEP-10 challenge-response flow:
+   * fetchChallenge → signChallenge → submitChallenge.
+   * Concurrent calls are deduplicated — a second call while one is in
+   * progress returns immediately without starting a new flow.
+   */
+  authenticate: (walletAddress: string) => Promise<void>;
+  /** Clears token, error, and in-flight guard so authentication can be retried */
+  reset: () => void;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useSep10Auth(
+  anchorDomain: string,
+  adapters: Sep10AuthAdapters,
+): UseSep10AuthResult {
+  const [token, setToken] = useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep refs so authenticate() always reads the latest domain and adapters
+  // even when callers pass new inline objects on every render.
+  const adaptersRef = useRef<Sep10AuthAdapters>(adapters);
+  adaptersRef.current = adapters;
+
+  const domainRef = useRef(anchorDomain);
+  domainRef.current = anchorDomain;
+
+  // In-flight guard: prevents duplicate concurrent SEP-10 flows.
+  const inFlightRef = useRef(false);
+
+  const authenticate = useCallback(async (walletAddress: string): Promise<void> => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setIsAuthenticating(true);
+    setError(null);
+
+    try {
+      const domain = domainRef.current;
+      const challengeXdr = await adaptersRef.current.fetchChallenge(domain, walletAddress);
+      const signedXdr = await adaptersRef.current.signChallenge(challengeXdr);
+      const jwt = await adaptersRef.current.submitChallenge(domain, signedXdr);
+      setToken(jwt);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Authentication failed. Please try again.',
+      );
+    } finally {
+      setIsAuthenticating(false);
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setToken(null);
+    setError(null);
+    setIsAuthenticating(false);
+    inFlightRef.current = false;
+  }, []);
+
+  return {
+    token,
+    isAuthenticated: token !== null,
+    isAuthenticating,
+    error,
+    authenticate,
+    reset,
+  };
+}

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/components'],
+  roots: ['<rootDir>/components', '<rootDir>/hooks'],
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: [


### PR DESCRIPTION
Closes #689

---

## Summary

- Adds `useAnchorHealth(attestor, interval, getHealthScore)` — a React hook that polls `get_anchor_health_score` at a configurable interval via an injectable adapter and returns live health data
- Exports `isValidAttestor` as a reusable Stellar StrKey validator
- Registers all new exports in `ui/hooks/index.ts`

## Hook API

```typescript
const {
  score,        // number | null — latest health score (0–100), null until first success
  loading,      // boolean — true only during the initial fetch
  error,        // string | null — user-friendly message from last failed poll
  lastUpdated,  // Date | null — timestamp of most recent successful score
} = useAnchorHealth(attestor, interval, getHealthScore);
```

```typescript
// Adapter type (injectable for testability)
type GetHealthScoreFn = (attestor: string) => Promise<number>;

// Address validator (also exported)
isValidAttestor('GABC...XYZ') // → boolean
```

## Design decisions

**Injectable `getHealthScore`** — the caller supplies the contract call as a function, decoupling the hook from any specific Soroban RPC client. This makes the hook trivially testable and reusable across different network environments.

**Adapter ref** — `getHealthScore` is stored in a `useRef` updated every render, so passing new inline arrow functions on each render never causes the timer to restart.

**`prevAttestorRef` distinguishes parameter-change types** — when only the interval changes, the current score is preserved and loading stays `false`; when the attestor changes, all state is reset and `loading` becomes `true` for the new initial fetch.

**Per-effect in-flight flag** — `inFlight` is a closure variable local to each effect invocation. If the previous poll is still awaiting when the interval fires, the new tick returns immediately (no duplicate requests). The flag resets to `false` once the outstanding poll settles.

**`loading` semantics** — `loading` is `true` only from the start of the initial fetch until the first result (score or error) arrives. Subsequent background polls run silently without touching `loading`.

**Stale score on error** — a failed poll sets `error` but keeps the last known `score` intact, so the UI can show stale data with a warning rather than going blank.

**Stellar StrKey validation** — `isValidAttestor` rejects null, undefined, empty strings, wrong-length strings, wrong leading character, and invalid base32 characters before any polling starts.

## Tests (41 total)

| Group | Count | Coverage |
|---|---|---|
| `isValidAttestor` | 9 | valid G/C addresses, null, undefined, empty, wrong char, too short/long, invalid base32 |
| Initial state | 5 | null/undefined/invalid attestor idle, loading=true before first poll, no polling without attestor |
| Successful polling | 5 | first poll resolves, correct attestor passed, C-address, score=0 not falsy, score=100 |
| Score updates | 4 | second poll updates score, lastUpdated advances, loading stays false, ticks at requested interval |
| Error handling | 5 | initial failure sets error, non-Error rejection fallback, stale score preserved, error cleared on recovery, error cleared on attestor change |
| Interval changes | 3 | shorter interval fires more often, old timer cancelled, score preserved on interval-only change |
| Attestor changes | 4 | state reset + loading=true, new attestor used, switching to null stops polling, null→valid starts polling |
| Cleanup | 3 | unmount cancels interval, in-flight on unmount is no-op, no timer leak |
| Overlapping prevention | 1 | in-flight tick skipped, allowed after resolution |
| Adapter stability | 2 | new inline ref doesn't restart timer, latest function used on each tick |

## Files changed

| File | Change |
|---|---|
| `ui/hooks/useAnchorHealth.ts` | New — hook + `isValidAttestor` |
| `ui/hooks/useAnchorHealth.test.ts` | New — 41 unit tests |
| `ui/hooks/index.ts` | Export `useAnchorHealth`, `isValidAttestor`, `GetHealthScoreFn`, `UseAnchorHealthResult` |