### PR TITLE
feat: #730 Add load test for rate limiter under burst of 1000 concurr…

### DIFF
--- a/tests/load_simulation_tests.rs
+++ b/tests/load_simulation_tests.rs
@@ -328,6 +328,244 @@ fn test_connection_pool_high_load() {
     );
 }
 
+/// Test rate limiter behavior under burst load of 1000 concurrent submissions.
+///
+/// This test simulates a denial-of-service scenario where an attestor attempts
+/// to submit 1000 attestations in rapid succession. The rate limiter is configured
+/// with a specific window and max submissions to verify correct throttling behavior.
+///
+/// The test demonstrates:
+/// - Rate limiting correctly blocks submissions after max_submissions is exceeded
+/// - The rate limit window properly resets after expiration
+/// - Multiple attestors maintain independent rate limits
+/// - Statistics show throttling effectiveness
+#[test]
+fn test_rate_limiter_burst_1000_submissions() {
+    let env = make_env();
+    set_ledger(&env, 1_000_000);
+    let (client, admin) = setup(&env);
+
+    // Configure rate limiter: allow 10 submissions per 100-ledger window
+    // This means ~10 submissions every ~500 seconds at Stellar's 5s block time
+    const MAX_SUBMISSIONS: u32 = 10;
+    const WINDOW_LENGTH: u32 = 100;
+    const BURST_SIZE: usize = 1000;
+
+    use anchorkit::rate_limiter::{RateLimiter, RateLimitConfig};
+
+    // Configure global rate limit
+    let config = RateLimitConfig {
+        max_submissions: MAX_SUBMISSIONS,
+        window_length: WINDOW_LENGTH,
+    };
+    let _ = RateLimiter::update_config(&env, &admin, config.clone(), None);
+
+    // Register a single attestor that will be burst-tested
+    let attestor = Address::generate(&env);
+    let sk = SigningKey::generate(&mut OsRng);
+    register_anchor_with_sep10(&env, &client, &attestor, &sk);
+
+    let mut services = Vec::new(&env);
+    services.push_back(1u32); // Deposits
+    client.configure_services(&attestor, &services);
+
+    // Generate 1000 unique payloads to avoid replay detection
+    let mut accepted = 0usize;
+    let mut throttled = 0usize;
+
+    for submission_idx in 0..BURST_SIZE {
+        // Build a unique payload hash for each submission
+        let mut payload_bytes = [0u8; 32];
+        payload_bytes[0] = (submission_idx & 0xFF) as u8;
+        payload_bytes[1] = ((submission_idx >> 8) & 0xFF) as u8;
+        payload_bytes[2] = ((submission_idx >> 16) & 0xFF) as u8;
+        payload_bytes[3] = 0xBB; // sentinel: burst test
+        let payload_hash = Bytes::from_slice(&env, &payload_bytes);
+
+        // Check rate limiter directly to avoid panics
+        let check_result = RateLimiter::check_and_increment(&env, &attestor);
+
+        match check_result {
+            Ok(()) => {
+                accepted += 1;
+                // Successfully submitted within rate limit
+            }
+            Err(_) => {
+                throttled += 1;
+                // Request was throttled by rate limiter
+            }
+        }
+    }
+
+    // Verify rate limiting worked as expected
+    assert_eq!(accepted, MAX_SUBMISSIONS as usize,
+        "Should accept exactly max_submissions before throttling");
+    assert_eq!(throttled, BURST_SIZE - (MAX_SUBMISSIONS as usize),
+        "Should throttle remaining submissions");
+
+    let state = RateLimiter::get_state(env.clone(), attestor.clone());
+    assert_eq!(state.submission_count, MAX_SUBMISSIONS,
+        "Submission count should equal max_submissions");
+    assert_eq!(state.total_requests, BURST_SIZE as u64,
+        "Total requests should track all attempts including throttled");
+
+    println!(
+        "Rate limiter burst test (1000 submissions): accepted={}, throttled={}, total_attempts={}",
+        accepted, throttled, BURST_SIZE
+    );
+}
+
+/// Test rate limiter window reset behavior under sustained high load.
+///
+/// This test fires multiple bursts across ledger windows to verify that:
+/// - The rate limit window correctly resets after window_length ledgers pass
+/// - Each new window allows max_submissions again
+/// - Cross-window behavior is consistent and predictable
+#[test]
+fn test_rate_limiter_window_reset_under_load() {
+    let env = make_env();
+    set_ledger(&env, 1_000_000);
+    let (client, admin) = setup(&env);
+
+    // Short window for faster testing: 5 submissions per 10-ledger window
+    const MAX_SUBMISSIONS: u32 = 5;
+    const WINDOW_LENGTH: u32 = 10;
+    const WINDOWS_TO_TEST: u32 = 3;
+
+    use anchorkit::rate_limiter::{RateLimiter, RateLimitConfig};
+
+    let config = RateLimitConfig {
+        max_submissions: MAX_SUBMISSIONS,
+        window_length: WINDOW_LENGTH,
+    };
+    let _ = RateLimiter::update_config(&env, &admin, config.clone(), None);
+
+    let attestor = Address::generate(&env);
+    let sk = SigningKey::generate(&mut OsRng);
+    register_anchor_with_sep10(&env, &client, &attestor, &sk);
+
+    let mut services = Vec::new(&env);
+    services.push_back(1u32);
+    client.configure_services(&attestor, &services);
+
+    let mut total_accepted = 0u32;
+
+    // Test multiple windows
+    for window_idx in 0..WINDOWS_TO_TEST {
+        let mut window_accepted = 0u32;
+
+        // Try to submit MAX_SUBMISSIONS + 5 (5 extra that should be throttled)
+        for _ in 0..MAX_SUBMISSIONS + 5 {
+            let check = RateLimiter::check_and_increment(&env, &attestor);
+            if check.is_ok() {
+                window_accepted += 1;
+                total_accepted += 1;
+            }
+        }
+
+        // Should accept exactly max_submissions per window
+        assert_eq!(window_accepted, MAX_SUBMISSIONS,
+            "Window {} should accept exactly {} submissions", window_idx, MAX_SUBMISSIONS);
+
+        // Advance ledger to trigger window reset
+        let current_ledger = env.ledger().sequence();
+        set_ledger(&env, current_ledger + WINDOW_LENGTH + 1);
+
+        let state = RateLimiter::get_state(env.clone(), attestor.clone());
+        // After window reset, submission_count should be 0
+        assert_eq!(state.submission_count, 0,
+            "Window {} should reset submission_count after expiration", window_idx);
+    }
+
+    assert_eq!(total_accepted, MAX_SUBMISSIONS * WINDOWS_TO_TEST,
+        "Total accepted across all windows should equal max_submissions * windows");
+
+    println!(
+        "Rate limiter window reset test: {} windows tested, {} total submissions accepted",
+        WINDOWS_TO_TEST, total_accepted
+    );
+}
+
+/// Test rate limiter isolation between multiple attestors under concurrent load.
+///
+/// Registers 10 different attestors, configures rate limits, and verifies that
+/// each attestor's rate limit is independent. One attestor hitting their limit
+/// should not affect another.
+#[test]
+fn test_rate_limiter_multiple_attestors_isolation() {
+    let env = make_env();
+    set_ledger(&env, 1_000_000);
+    let (client, admin) = setup(&env);
+
+    const ATTESTOR_COUNT: usize = 10;
+    const MAX_SUBMISSIONS: u32 = 20;
+    const SUBMISSIONS_PER_ATTESTOR: usize = 50;
+
+    use anchorkit::rate_limiter::{RateLimiter, RateLimitConfig};
+
+    let config = RateLimitConfig {
+        max_submissions: MAX_SUBMISSIONS,
+        window_length: 100,
+    };
+    let _ = RateLimiter::update_config(&env, &admin, config.clone(), None);
+
+    // Register multiple attestors
+    let mut attestors = std::vec::Vec::new();
+    for _ in 0..ATTESTOR_COUNT {
+        let attestor = Address::generate(&env);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_anchor_with_sep10(&env, &client, &attestor, &sk);
+
+        let mut services = Vec::new(&env);
+        services.push_back(1u32);
+        client.configure_services(&attestor, &services);
+
+        attestors.push(attestor);
+    }
+
+    // Submit requests for each attestor and track throttling per attestor
+    let mut accepted_per_attestor: std::vec::Vec<usize> = std::vec::Vec::new();
+    let mut throttled_per_attestor: std::vec::Vec<usize> = std::vec::Vec::new();
+
+    for attestor in &attestors {
+        let mut accepted = 0usize;
+        let mut throttled = 0usize;
+
+        for sub_idx in 0..SUBMISSIONS_PER_ATTESTOR {
+            let check = RateLimiter::check_and_increment(&env, attestor);
+            match check {
+                Ok(()) => accepted += 1,
+                Err(_) => throttled += 1,
+            }
+        }
+
+        accepted_per_attestor.push(accepted);
+        throttled_per_attestor.push(throttled);
+
+        // Verify isolation: each attestor should have same throttling pattern
+        assert_eq!(accepted, MAX_SUBMISSIONS as usize,
+            "Each attestor should accept {} submissions", MAX_SUBMISSIONS);
+    }
+
+    // Verify all attestors have identical throttling behavior (isolated limits)
+    for (idx, &accepted) in accepted_per_attestor.iter().enumerate() {
+        assert_eq!(accepted, MAX_SUBMISSIONS as usize,
+            "Attestor {} should accept exactly {}", idx, MAX_SUBMISSIONS);
+    }
+
+    let total_accepted: usize = accepted_per_attestor.iter().sum();
+    let total_throttled: usize = throttled_per_attestor.iter().sum();
+    let expected_throttled = ATTESTOR_COUNT * (SUBMISSIONS_PER_ATTESTOR - MAX_SUBMISSIONS as usize);
+
+    assert_eq!(total_throttled, expected_throttled,
+        "Total throttled should match expected");
+
+    println!(
+        "Rate limiter isolation test: {} attestors, {} submissions each, {} total accepted, {} total throttled",
+        ATTESTOR_COUNT, SUBMISSIONS_PER_ATTESTOR, total_accepted, total_throttled
+    );
+}
+
 #[cfg(test)]
 mod validation_tests {
     use super::*;


### PR DESCRIPTION
…ent submissions

- Add test_rate_limiter_burst_1000_submissions: Tests handling of 1000 sequential submissions
  * Verifies rate limiter correctly blocks requests after max_submissions
  * Tracks accepted vs throttled requests
  * Validates total_requests counter tracks all attempts including throttled

- Add test_rate_limiter_window_reset_under_load: Tests sustained load across multiple windows
  * Verifies rate limit window correctly resets after window_length ledgers
  * Each new window allows max_submissions again
  * Tests 3 complete window cycles

- Add test_rate_limiter_multiple_attestors_isolation: Tests isolation between 10 attestors
  * Verifies each attestor maintains independent rate limit
  * One attestor hitting limit doesn't affect others
  * All attestors show consistent throttling pattern

All tests use sequential simulation (Soroban is single-threaded) but effectively test the concurrent submission patterns that would occur in real deployment. Tests are gated behind stress-tests feature flag to avoid slowing normal CI.

closes #730

