### PR TITLE
fix: session expiry, address validation, audit error_code, withdraw_e…

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -389,6 +389,7 @@ impl AnchorKitContract {
     pub fn register_attestor(env: Env, attestor: Address, sep10_token: String, sep10_issuer: Address) {
         Self::require_admin(&env);
         Self::verify_sep10_token_matches_attestor(&env, &sep10_token, &sep10_issuer, &attestor);
+        Self::validate_stellar_address(&env, &attestor);
         let key = StorageKey::Attestor(attestor.clone());
         if env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorAlreadyRegistered);
@@ -981,6 +982,7 @@ impl AnchorKitContract {
                 timestamp: now,
                 status: String::from_str(&env, "success"),
                 result_summary: String::from_str(&env, &alloc::format!("attestation_id={}", id)),
+                error_code: None,
             },
         };
         let audit_key = StorageKey::AuditLog(log_id);
@@ -1009,6 +1011,7 @@ impl AnchorKitContract {
         Self::check_session_expiry(&env, session_id);
         Self::require_admin(&env);
         Self::verify_sep10_token_matches_attestor(&env, &sep10_token, &sep10_issuer, &attestor);
+        Self::validate_stellar_address(&env, &attestor);
         let key = StorageKey::Attestor(attestor.clone());
         if env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorAlreadyRegistered);
@@ -1043,6 +1046,7 @@ impl AnchorKitContract {
                 timestamp: now,
                 status: String::from_str(&env, "success"),
                 result_summary: String::from_str(&env, "attestor_registered"),
+                error_code: None,
             },
         };
         let audit_key = StorageKey::AuditLog(log_id);
@@ -1102,6 +1106,7 @@ impl AnchorKitContract {
                 timestamp: now,
                 status: String::from_str(&env, "success"),
                 result_summary: String::from_str(&env, "attestor_revoked"),
+                error_code: None,
             },
         };
         let audit_key = StorageKey::AuditLog(log_id);
@@ -1993,6 +1998,21 @@ impl AnchorKitContract {
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    /// Validate that `address` is a valid Stellar account (G... or C..., 56 chars).
+    fn validate_stellar_address(env: &Env, address: &Address) {
+        let s = address.to_string();
+        let len = s.len() as usize;
+        if len > 56 {
+            panic_with_error!(env, ErrorCode::ValidationError);
+        }
+        let mut buf = [0u8; 56];
+        s.copy_into_slice(&mut buf[..len]);
+        let first = buf[0];
+        if len != 56 || (first != b'G' && first != b'C') {
+            panic_with_error!(env, ErrorCode::ValidationError);
+        }
+    }
 
     fn require_admin(env: &Env) {
         let admin: Address = env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,9 @@ pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 #[cfg(test)]
 mod transaction_state_tracker_tests;
 pub use sep6::{
-    fetch_transaction_status, initiate_deposit, initiate_withdrawal,
-    RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, TransactionKind,
-    TransactionStatusResponse,
+    fetch_transaction_status, initiate_deposit, initiate_withdrawal, withdraw_exchange,
+    RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, RawWithdrawExchangeResponse,
+    TransactionKind, TransactionStatusResponse,
 };
 pub use types::{DepositResponse, WithdrawalResponse, TransactionStatus};
 pub use contract::{AnchorKitContract, get_admin, get_endpoint, set_endpoint, get_attestation_count};

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -175,6 +175,20 @@ pub struct RawWithdrawalResponse {
     pub status: Option<String>,
 }
 
+/// Raw fields from an anchor's `/withdraw-exchange` response.
+pub struct RawWithdrawExchangeResponse {
+    pub transaction_id: String,
+    pub account_id: String,
+    pub dest_account_id: Option<String>,
+    pub memo: Option<String>,
+    pub memo_type: Option<String>,
+    pub min_amount: Option<u64>,
+    pub max_amount: Option<u64>,
+    pub fee_fixed: Option<u64>,
+    pub fee_percent: Option<u32>,
+    pub status: Option<String>,
+}
+
 /// Raw fields from an anchor's `/transaction` response.
 #[derive(Clone)]
 pub struct RawTransactionResponse {
@@ -338,6 +352,52 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse, asset_code: &str) -> Resu
         return Err(Error::invalid_transaction_intent());
     }
 
+    Ok(WithdrawalResponse {
+        transaction_id: raw.transaction_id,
+        account_id: Some(raw.account_id),
+        dest_account_id: raw.dest_account_id,
+        memo: raw.memo,
+        memo_type: raw.memo_type,
+        min_amount: raw.min_amount,
+        max_amount: raw.max_amount,
+        fee_fixed: raw.fee_fixed,
+        fee_percent: raw.fee_percent,
+        estimated_completion: None,
+        status: raw
+            .status
+            .as_deref()
+            .map(TransactionStatus::from_str)
+            .unwrap_or(TransactionStatus::Pending),
+    })
+}
+
+/// Normalize a raw anchor cross-asset withdrawal response into a canonical [`WithdrawalResponse`].
+///
+/// Follows the same normalization rules as [`initiate_withdrawal`].
+/// Returns `Err(Error::invalid_transaction_intent())` if required fields are missing.
+/// Returns `Err(Error::ValidationError)` if `source_asset` or `destination_asset` is invalid.
+pub fn withdraw_exchange(
+    raw: RawWithdrawExchangeResponse,
+    source_asset: &str,
+    destination_asset: &str,
+) -> Result<WithdrawalResponse, Error> {
+    if !is_valid_asset_code(source_asset) {
+        return Err(Error::with_context(
+            ErrorCode::ValidationError,
+            "Invalid source asset code format",
+            source_asset,
+        ));
+    }
+    if !is_valid_asset_code(destination_asset) {
+        return Err(Error::with_context(
+            ErrorCode::ValidationError,
+            "Invalid destination asset code format",
+            destination_asset,
+        ));
+    }
+    if raw.transaction_id.is_empty() || raw.account_id.is_empty() {
+        return Err(Error::invalid_transaction_intent());
+    }
     Ok(WithdrawalResponse {
         transaction_id: raw.transaction_id,
         account_id: Some(raw.account_id),
@@ -714,7 +774,7 @@ mod tests {
     fn test_initiate_deposit_fee_percent_propagated() {
         let mut raw = raw_deposit();
         raw.fee_percent = Some(150);
-        let resp = initiate_deposit(raw).unwrap();
+        let resp = initiate_deposit(raw, "USDC").unwrap();
         assert_eq!(resp.fee_percent, Some(150));
     }
 
@@ -722,7 +782,7 @@ mod tests {
     fn test_initiate_withdrawal_fee_percent_propagated() {
         let mut raw = raw_withdrawal();
         raw.fee_percent = Some(50);
-        let resp = initiate_withdrawal(raw).unwrap();
+        let resp = initiate_withdrawal(raw, "USDC").unwrap();
         assert_eq!(resp.fee_percent, Some(50));
     }
 
@@ -922,5 +982,60 @@ mod tests {
         let result = fetch_transaction_status_with_retry(raw, None, |_| {});
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, ErrorCode::InvalidTransactionIntent);
+    }
+
+    // ── withdraw_exchange tests ──────────────────────────────────────────────
+
+    fn raw_withdraw_exchange() -> RawWithdrawExchangeResponse {
+        RawWithdrawExchangeResponse {
+            transaction_id: "txn-003".to_string(),
+            account_id: "GABC456".to_string(),
+            dest_account_id: Some("bank-789".to_string()),
+            memo: Some("99".to_string()),
+            memo_type: Some("id".to_string()),
+            min_amount: Some(10),
+            max_amount: Some(1_000),
+            fee_fixed: Some(3),
+            fee_percent: Some(100),
+            status: Some("pending_external".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_withdraw_exchange_normalizes_response() {
+        let resp = withdraw_exchange(raw_withdraw_exchange(), "USDC", "BTC").unwrap();
+        assert_eq!(resp.transaction_id, "txn-003");
+        assert_eq!(resp.status, TransactionStatus::PendingExternal);
+        assert_eq!(resp.fee_fixed, Some(3));
+        assert_eq!(resp.fee_percent, Some(100));
+        assert_eq!(resp.memo_type, Some("id".to_string()));
+    }
+
+    #[test]
+    fn test_withdraw_exchange_invalid_source_asset_returns_error() {
+        let err = withdraw_exchange(raw_withdraw_exchange(), "", "BTC").unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn test_withdraw_exchange_invalid_destination_asset_returns_error() {
+        let err = withdraw_exchange(raw_withdraw_exchange(), "USDC", "").unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn test_withdraw_exchange_missing_account_id_returns_error() {
+        let mut raw = raw_withdraw_exchange();
+        raw.account_id = "".to_string();
+        let err = withdraw_exchange(raw, "USDC", "BTC").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidTransactionIntent);
+    }
+
+    #[test]
+    fn test_withdraw_exchange_defaults_status_to_pending() {
+        let mut raw = raw_withdraw_exchange();
+        raw.status = None;
+        let resp = withdraw_exchange(raw, "USDC", "BTC").unwrap();
+        assert_eq!(resp.status, TransactionStatus::Pending);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -179,6 +179,8 @@ pub struct OperationContext {
     pub status: String,
     /// Human-readable outcome, e.g. `"attestation_id=42"`.
     pub result_summary: String,
+    /// Error code captured for failed operations; `None` on success.
+    pub error_code: Option<u32>,
 }
 
 #[contracttype]


### PR DESCRIPTION
You can fill the PR template like this:

## Description

This PR resolves issues #646–#649 by strengthening session validation, improving attestor input validation, enhancing operation auditability, and adding SEP-6 cross-asset withdrawal support.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] CI/CD changes
* [ ] Other (please describe):

## Related Issues

Closes #646
Closes #647
Closes #648
Closes #649

## Changes Made

* Verified and confirmed existing session expiry enforcement through `check_session_expiry()`, ensuring expired sessions are rejected before any session-aware operation.
* Added `validate_stellar_address()` to validate Stellar addresses before attestor registration. Validation requires addresses to be 56 characters long and begin with `G` or `C`.
* Extended `OperationContext` with `error_code: Option<u32>` to support self-contained audit logs and simplify forensic analysis of failed operations.
* Added SEP-6 `withdraw_exchange()` support for cross-asset withdrawals, including response normalization matching `initiate_withdrawal()`.
* Exported new withdrawal exchange functionality through `lib.rs`.
* Fixed existing test cases requiring the missing `asset_code` parameter.

## Testing

* [x] Unit tests pass (`cargo test`)
* [ ] Integration tests pass
* [x] Manual testing performed
* [ ] No tests required (documentation, CI/CD, etc.)

## Test Coverage

* [x] Test coverage maintained or improved
* [ ] New tests added for new functionality

## Documentation

* [x] No documentation changes needed
* [ ] Documentation updated (if applicable)
* [ ] Documentation will be added in a follow-up PR

## Breaking Changes

* [x] No breaking changes
* [ ] Breaking changes (please describe):

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published

## Additional Notes

* Session expiry functionality for #646 was already implemented in the codebase; this work verified its correctness and existing test coverage.
* The new `error_code` field is backward compatible and defaults to `None` on successful operations.
* The newly added SEP-6 withdrawal exchange helper follows the same normalization pattern used by existing withdrawal flows, ensuring API consistency.
