### PR TITLE
feat(#679): add AnchorSelector component with health scores and auto-select

### DIFF
--- a/ui/components/AnchorSelector.tsx
+++ b/ui/components/AnchorSelector.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect } from "react";
+
+export interface AnchorOption {
+  id: string;
+  name: string;
+  endpoint?: string;
+  healthScore: number; // 0–100
+}
+
+export interface AnchorSelectorProps {
+  anchors: AnchorOption[];
+  /** Pre-selected anchor id. If omitted the component auto-selects the highest-scoring anchor. */
+  selectedId?: string;
+  onChange: (anchor: AnchorOption) => void;
+  /** Minimum health score an anchor must have to be considered auto-selectable (default: 0). */
+  minHealthScore?: number;
+  className?: string;
+}
+
+function scoreColor(score: number): string {
+  if (score >= 80) return "#16a34a";
+  if (score >= 60) return "#d97706";
+  return "#dc2626";
+}
+
+function scoreLabel(score: number): string {
+  if (score >= 80) return "Healthy";
+  if (score >= 60) return "Degraded";
+  return "Unhealthy";
+}
+
+export function AnchorSelector({
+  anchors,
+  selectedId,
+  onChange,
+  minHealthScore = 0,
+  className,
+}: AnchorSelectorProps) {
+  const eligible = anchors.filter((a) => a.healthScore >= minHealthScore);
+  const best = eligible.length > 0
+    ? eligible.reduce((a, b) => (b.healthScore > a.healthScore ? b : a))
+    : null;
+
+  const [selected, setSelected] = useState<string | null>(
+    selectedId ?? best?.id ?? null
+  );
+
+  // Sync if selectedId prop changes
+  useEffect(() => {
+    if (selectedId !== undefined) setSelected(selectedId);
+  }, [selectedId]);
+
+  // Notify parent when internal selection changes
+  useEffect(() => {
+    if (selected == null) return;
+    const anchor = anchors.find((a) => a.id === selected);
+    if (anchor) onChange(anchor);
+  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (anchors.length === 0) {
+    return (
+      <div
+        role="status"
+        style={{ padding: "12px 16px", color: "#64748b", fontSize: 13 }}
+        className={className}
+      >
+        No anchors available.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Select anchor"
+      className={className}
+      style={{ display: "flex", flexDirection: "column", gap: 8 }}
+    >
+      {anchors.map((anchor) => {
+        const isSelected = anchor.id === selected;
+        const isDisabled = anchor.healthScore < minHealthScore;
+        const color = scoreColor(anchor.healthScore);
+
+        return (
+          <div
+            key={anchor.id}
+            role="option"
+            aria-selected={isSelected}
+            aria-disabled={isDisabled}
+            tabIndex={isDisabled ? -1 : 0}
+            onClick={() => {
+              if (!isDisabled) setSelected(anchor.id);
+            }}
+            onKeyDown={(e) => {
+              if (!isDisabled && (e.key === "Enter" || e.key === " ")) {
+                e.preventDefault();
+                setSelected(anchor.id);
+              }
+            }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "10px 14px",
+              borderRadius: 10,
+              border: `2px solid ${isSelected ? color : "#e2e8f0"}`,
+              background: isSelected ? `${color}12` : "#fff",
+              cursor: isDisabled ? "not-allowed" : "pointer",
+              opacity: isDisabled ? 0.5 : 1,
+              transition: "border-color 0.15s, background 0.15s",
+              outline: "none",
+            }}
+          >
+            {/* Left: name + endpoint */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              <span style={{ fontWeight: 600, fontSize: 14, color: "#0f172a" }}>
+                {anchor.name}
+                {anchor.id === best?.id && (
+                  <span
+                    style={{
+                      marginLeft: 8,
+                      fontSize: 10,
+                      fontWeight: 700,
+                      letterSpacing: "0.08em",
+                      textTransform: "uppercase",
+                      padding: "1px 6px",
+                      borderRadius: 8,
+                      background: "#dcfce7",
+                      color: "#16a34a",
+                    }}
+                  >
+                    Best
+                  </span>
+                )}
+              </span>
+              {anchor.endpoint && (
+                <span style={{ fontSize: 11, color: "#64748b", fontFamily: "monospace" }}>
+                  {anchor.endpoint}
+                </span>
+              )}
+            </div>
+
+            {/* Right: health score badge */}
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
+              <span style={{ fontSize: 18, fontWeight: 700, color, lineHeight: 1 }}>
+                {anchor.healthScore}
+              </span>
+              <span style={{ fontSize: 10, fontWeight: 600, color, textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                {scoreLabel(anchor.healthScore)}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/components/index.ts
+++ b/ui/components/index.ts
@@ -6,3 +6,9 @@
 
 export { ApiRequestPanel } from './ApiRequestPanel';
 export type { ApiRequestPanelProps } from './ApiRequestPanel';
+
+export { AnchorSelector } from './AnchorSelector';
+export type { AnchorSelectorProps, AnchorOption } from './AnchorSelector';
+
+export { TransactionTimeline } from './TransactionTimeline';
+export type { TransactionTimelineProps, TxEvent, TxStatus, TxType } from './TransactionTimeline';


### PR DESCRIPTION

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using "Closes #123" or "Fixes #123" format -->
Closes #679 

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No tests required (documentation, CI/CD, etc.)

## Test Coverage
<!-- If applicable, mention test coverage changes -->
- [ ] Test coverage maintained or improved
- [ ] New tests added for new functionality

## Documentation
<!-- Mark the appropriate option with an "x" -->
- [ ] Documentation updated (if applicable)
- [ ] No documentation changes needed
- [ ] Documentation will be added in a follow-up PR

## Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
- [ ] No breaking changes
- [ ] Breaking changes (please describe):

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
