### PR TITLE
fix(#682): use useCopyToClipboard hook in JsonViewer

### DIFF
--- a/ui/components/JsonViewer.tsx
+++ b/ui/components/JsonViewer.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -595,7 +596,7 @@ export function JsonViewer({
   const t = THEMES[themeName];
   const [mode, setMode] = useState<ViewerMode>(defaultMode);
   const [search, setSearch] = useState("");
-  const [copied, setCopied] = useState(false);
+  const { isCopied: copied, copy: copyToClipboard } = useCopyToClipboard();
   
   // Remove circular references before processing
   const safeData = useMemo(() => removeCircularReferences(data), [data]);
@@ -635,11 +636,7 @@ export function JsonViewer({
 
   const collapseAll = () => setExpandedPaths(new Set());
 
-  const copy = () => {
-    navigator.clipboard.writeText(json);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
+  const copy = () => copyToClipboard(json);
 
   // Reset line counter on each render
   lineRef.current = 0;


### PR DESCRIPTION
## Summary

Closes #682

The existing copy button in `JsonViewer` used a raw `navigator.clipboard.writeText` call plus hand-rolled `setCopied`/`setTimeout` state. This diverged from the dedicated `useCopyToClipboard` hook that already ships in the repo.

## Changes

**`ui/components/JsonViewer.tsx`**
- Added `import { useCopyToClipboard } from "../hooks/useCopyToClipboard"`
- Removed the `[copied, setCopied]` state pair
- Removed the inline `copy()` function that called `navigator.clipboard.writeText` and `setTimeout`
- Replaced with `const { isCopied: copied, copy: copyToClipboard } = useCopyToClipboard()`
- The toolbar copy button now calls `copyToClipboard(json)`

## Benefits over the old approach

| | Old | New |
|---|---|---|
| Clipboard API | `navigator.clipboard` only | Clipboard API + `execCommand` fallback |
| Success duration | Hard-coded 1.5 s `setTimeout` | Configurable (default 2 s), auto-cleared on unmount |
| Feedback state | Manual `setCopied` | Managed by hook |
| Reusability | None | Shared hook used across the codebase |

## Testing

- Click the ⎘ Copy button → button text changes to ✓ Copied for 2 s, then resets
- Copied text matches the pretty-printed JSON displayed in the viewer