### PR TITLE
fix(#684): show SkeletonLoader during challenge fetch in Sep10AuthFlow

### DIFF
--- a/ui/components/Sep10AuthFlow.tsx
+++ b/ui/components/Sep10AuthFlow.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useSep10Auth } from "../hooks/useSep10Auth";
+import { SkeletonLoader } from "./SkeletonLoader";
 
 import './themes.css';
 
@@ -815,13 +816,20 @@ export default function SEP10AuthFlow() {
             The anchor generates a unique challenge transaction. This XDR must
             be signed by your wallet to prove key ownership.
           </p>
-          <button
-            onClick={fetchChallenge}
-            disabled={loading || !wallet}
-            style={btnStyle(NEON, loading || !wallet)}
-          >
-            {loading ? <Spinner /> : <>{fetchIcon} Fetch Challenge</>}
-          </button>
+          {loading ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <SkeletonLoader variant="text" width="70%" height={10} dark />
+              <SkeletonLoader variant="rect" width="100%" height={56} dark />
+            </div>
+          ) : (
+            <button
+              onClick={fetchChallenge}
+              disabled={loading || !wallet}
+              style={btnStyle(NEON, loading || !wallet)}
+            >
+              <>{fetchIcon} Fetch Challenge</>
+            </button>
+          )}
         </div>
       ),
     },


### PR DESCRIPTION
## Summary

Closes #684

While `Sep10AuthFlow` was fetching the SEP-10 challenge from the anchor, the challenge step content area was completely blank. Users had no visual feedback that work was in progress.

## Changes

**`ui/components/Sep10AuthFlow.tsx`**
- Added `import { SkeletonLoader } from "./SkeletonLoader"`
- In the challenge step's idle/not-yet-fetched branch, replaced the unconditional button render with a condition:
  - **When `loading === true`**: renders two `<SkeletonLoader>` rows that mirror the form layout — a narrow text-width line (simulating the "CHALLENGE XDR" label) and a taller rect (simulating the XDR code block)
  - **When `loading === false`**: renders the Fetch Challenge button as before
- Removed the inline `{loading ? <Spinner /> : …}` ternary from the button since the skeleton now covers the loading state; the `<Spinner />` inside the button is no longer needed here

## Before / After

| State | Before | After |
|---|---|---|
| Idle (wallet connected) | Fetch Challenge button | Fetch Challenge button |
| Loading | Button with spinner (brief blank gap) | Two skeleton placeholder rows |
| Done | Challenge XDR block | Challenge XDR block (unchanged) |

## Design

The skeleton uses `dark` mode colours (`rgba(255,255,255,0.05/0.08)`) consistent with the component's existing dark UI. Row dimensions (10 px label height, 56 px block height) match the rendered challenge display block.