### PR TITLE
feat(ui): add click-to-expand detail panels to TransactionTimeline steps

### DIFF
--- a/ui/components/TransactionTimeline.stories.tsx
+++ b/ui/components/TransactionTimeline.stories.tsx
@@ -9,9 +9,9 @@ const minsAgo = (n: number) => new Date(Date.now() - n * 60_000).toISOString();
 // ─── Per-story event fixtures ──────────────────────────────────────────────────
 
 const PENDING_EVENTS: TxEvent[] = [
-  { status: "initiated",     timestamp: minsAgo(14), detail: "via ACH transfer" },
-  { status: "awaiting_user", timestamp: minsAgo(12), detail: "Reference: ANC-20240115-0042" },
-  { status: "pending",       timestamp: minsAgo(3),  description: "Funds detected on the ACH rail — awaiting settlement." },
+  { status: "initiated",     timestamp: minsAgo(14), detail: "via ACH transfer", rawApiResponse: { transaction: { id: "dep_8f3c1a9e2b", status: "completed", kind: "deposit", amount_in: "250.00", asset_code: "USDC" } } },
+  { status: "awaiting_user", timestamp: minsAgo(12), detail: "Reference: ANC-20240115-0042", rawApiResponse: { transaction: { id: "dep_8f3c1a9e2b", status: "pending_user_transfer_start", more_info_url: "https://anchor.example.com/sep24/transaction/dep_8f3c1a9e2b" } } },
+  { status: "pending",       timestamp: minsAgo(3),  description: "Funds detected on the ACH rail — awaiting settlement.", rawApiResponse: { transaction: { id: "dep_8f3c1a9e2b", status: "pending_external", amount_in: "250.00", amount_fee: "1.50" } } },
 ];
 
 const AWAITING_USER_EVENTS: TxEvent[] = [
@@ -33,14 +33,16 @@ const COMPLETED_EVENTS: TxEvent[] = [
 ];
 
 const FAILED_EVENTS: TxEvent[] = [
-  { status: "initiated",     timestamp: minsAgo(50), detail: "to SEPA •••• 4821" },
-  { status: "awaiting_user", timestamp: minsAgo(49) },
-  { status: "pending",       timestamp: minsAgo(44) },
+  { status: "initiated",     timestamp: minsAgo(50), detail: "to SEPA •••• 4821", rawApiResponse: { transaction: { id: "wdl_9b3e7c1a4f", status: "completed", kind: "withdrawal" } } },
+  { status: "awaiting_user", timestamp: minsAgo(49), rawApiResponse: { transaction: { id: "wdl_9b3e7c1a4f", status: "pending_user_transfer_start" } } },
+  { status: "pending",       timestamp: minsAgo(44), rawApiResponse: { transaction: { id: "wdl_9b3e7c1a4f", status: "pending_external" } } },
   {
     status: "failed",
     timestamp: minsAgo(22),
     label: "Bank Rejected",
     description: "Destination bank rejected the transfer. Please verify your IBAN and try again.",
+    error: "SEPA transfer declined: invalid IBAN checksum (error code: RJCT-AC01)",
+    rawApiResponse: { transaction: { id: "wdl_9b3e7c1a4f", status: "error", message: "Bank rejected: invalid IBAN", external_transaction_id: "SEPA-20240115-9821" } },
   },
 ];
 

--- a/ui/components/TransactionTimeline.tsx
+++ b/ui/components/TransactionTimeline.tsx
@@ -14,6 +14,8 @@ export interface TxEvent {
   timestamp?: string;         // ISO string or readable label
   txHash?: string;            // on-chain hash, shown on completed
   detail?: string;            // any extra note
+  rawApiResponse?: unknown;   // raw API response payload for debugging
+  error?: string;             // error message if this step failed
 }
 
 export interface TransactionTimelineProps {
@@ -178,6 +180,7 @@ export function TransactionTimeline({
   const currentIndex = getOrderIndex(currentStatus);
 
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
+  const [expandedStep, setExpandedStep] = useState<TxStatus | null>(null);
 
   useEffect(() => {
     if (!estimatedCompletionAt || completed || failed) {
@@ -325,59 +328,118 @@ export function TransactionTimeline({
 
                 {/* Content */}
                 <div style={{ flex: 1, paddingTop: 8, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
-                    <span style={{
-                      ...sans, fontSize: 13, fontWeight: 600,
-                      color: step.isDone || step.isActive ? "var(--ak-text)" : "var(--ak-text-subtle)",
+                  <div
+                    onClick={() => setExpandedStep(expandedStep === step.status ? null : step.status)}
+                    style={{ cursor: "pointer", userSelect: "none" }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+                      <span style={{
+                        ...sans, fontSize: 13, fontWeight: 600,
+                        color: step.isDone || step.isActive ? "var(--ak-text)" : "var(--ak-text-subtle)",
+                        transition: "color 0.4s",
+                      }}>
+                        {step.event?.label ?? step.m.label}
+                      </span>
+                      {step.isDone && !step.isActive && (
+                        <span style={{
+                          ...mono, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em",
+                          padding: "2px 7px", borderRadius: 10,
+                          background: step.m.bg, color: step.m.color,
+                          border: `1px solid ${step.m.border}`,
+                        }}>DONE</span>
+                      )}
+                      {step.isActive && (
+                        <span style={{
+                          ...mono, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em",
+                          padding: "2px 7px", borderRadius: 10,
+                          background: step.m.bg, color: step.m.color,
+                          border: `1px solid ${step.m.border}`,
+                          animation: "txs-fade-in-out 1.8s ease-in-out infinite",
+                        }}>LIVE</span>
+                      )}
+                      <span style={{
+                        ...mono, fontSize: 10, color: "var(--ak-text-subtle)", marginLeft: "auto",
+                        transition: "transform 0.2s",
+                        display: "inline-block",
+                        transform: expandedStep === step.status ? "rotate(180deg)" : "rotate(0deg)",
+                      }}>▾</span>
+                    </div>
+
+                    <p style={{
+                      ...sans, fontSize: 12, color: step.isDone || step.isActive ? "var(--ak-text-muted)" : "var(--ak-text-subtle)",
+                      lineHeight: 1.55, margin: 0,
                       transition: "color 0.4s",
                     }}>
-                      {step.event?.label ?? step.m.label}
-                    </span>
-                    {step.isDone && !step.isActive && (
-                      <span style={{
-                        ...mono, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em",
-                        padding: "2px 7px", borderRadius: 10,
-                        background: step.m.bg, color: step.m.color,
-                        border: `1px solid ${step.m.border}`,
-                      }}>DONE</span>
-                    )}
-                    {step.isActive && (
-                      <span style={{
-                        ...mono, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em",
-                        padding: "2px 7px", borderRadius: 10,
-                        background: step.m.bg, color: step.m.color,
-                        border: `1px solid ${step.m.border}`,
-                        animation: "txs-fade-in-out 1.8s ease-in-out infinite",
-                      }}>LIVE</span>
-                    )}
+                      {desc}
+                    </p>
+
+                    {/* Extra metadata row */}
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 12px", marginTop: 6 }}>
+                      {ts && (
+                        <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-muted)" }}>{ts}</span>
+                      )}
+                      {step.event?.txHash && (
+                        <a
+                          href={`https://stellar.expert/explorer/testnet/tx/${step.event.txHash}`}
+                          target="_blank" rel="noreferrer"
+                          onClick={e => e.stopPropagation()}
+                          style={{ ...mono, fontSize: 10, color: "var(--ak-status-initiated-color)", textDecoration: "none", display: "flex", alignItems: "center", gap: 3 }}
+                        >
+                          ↗ {truncateHash(step.event.txHash)}
+                        </a>
+                      )}
+                      {step.event?.detail && (
+                        <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-muted)" }}>{step.event.detail}</span>
+                      )}
+                    </div>
                   </div>
 
-                  <p style={{
-                    ...sans, fontSize: 12, color: step.isDone || step.isActive ? "var(--ak-text-muted)" : "var(--ak-text-subtle)",
-                    lineHeight: 1.55, margin: 0,
-                    transition: "color 0.4s",
-                  }}>
-                    {desc}
-                  </p>
+                  {/* Expandable detail panel */}
+                  {expandedStep === step.status && (
+                    <div style={{
+                      marginTop: 10, padding: "12px 14px",
+                      borderRadius: 10, border: "1px solid var(--ak-border)",
+                      background: "var(--ak-surface-2)",
+                      display: "flex", flexDirection: "column", gap: 8,
+                    }}>
+                      {/* Timestamp */}
+                      {step.event?.timestamp && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-text-subtle)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Timestamp</span>
+                          <span style={{ ...mono, fontSize: 11, color: "var(--ak-text-muted)" }}>{step.event.timestamp}</span>
+                        </div>
+                      )}
 
-                  {/* Extra metadata row */}
-                  <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 12px", marginTop: 6 }}>
-                    {ts && (
-                      <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-muted)" }}>{ts}</span>
-                    )}
-                    {step.event?.txHash && (
-                      <a
-                        href={`https://stellar.expert/explorer/testnet/tx/${step.event.txHash}`}
-                        target="_blank" rel="noreferrer"
-                        style={{ ...mono, fontSize: 10, color: "var(--ak-status-initiated-color)", textDecoration: "none", display: "flex", alignItems: "center", gap: 3 }}
-                      >
-                        ↗ {truncateHash(step.event.txHash)}
-                      </a>
-                    )}
-                    {step.event?.detail && (
-                      <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-muted)" }}>{step.event.detail}</span>
-                    )}
-                  </div>
+                      {/* Error */}
+                      {step.event?.error && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-status-failed-color)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Error</span>
+                          <span style={{ ...mono, fontSize: 11, color: "var(--ak-status-failed-color)" }}>{step.event.error}</span>
+                        </div>
+                      )}
+
+                      {/* Raw API response */}
+                      {step.event?.rawApiResponse !== undefined && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-text-subtle)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Raw API Response</span>
+                          <pre style={{
+                            ...mono, fontSize: 10, color: "var(--ak-text)",
+                            background: "var(--ak-surface-3)", padding: "10px 12px",
+                            borderRadius: 8, border: "1px solid var(--ak-border)",
+                            overflowX: "auto", margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-all",
+                            maxHeight: 200, overflowY: "auto",
+                          }}>
+                            {JSON.stringify(step.event.rawApiResponse, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+
+                      {/* Fallback when no extra data */}
+                      {!step.event?.timestamp && !step.event?.error && step.event?.rawApiResponse === undefined && (
+                        <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-subtle)" }}>No additional details available.</span>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             );
@@ -398,17 +460,52 @@ export function TransactionTimeline({
                 }}>✕</div>
               </div>
               <div style={{ flex: 1, paddingTop: 8 }}>
-                <div style={{ ...sans, fontSize: 13, fontWeight: 600, color: "var(--ak-status-failed-color)", marginBottom: 4 }}>
-                  {events.find(e => e.status === "failed")?.label ?? "Transaction Failed"}
+                <div
+                  onClick={() => setExpandedStep(expandedStep === "failed" ? null : "failed")}
+                  style={{ cursor: "pointer", userSelect: "none" }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+                    <span style={{ ...sans, fontSize: 13, fontWeight: 600, color: "var(--ak-status-failed-color)" }}>
+                      {events.find(e => e.status === "failed")?.label ?? "Transaction Failed"}
+                    </span>
+                    <span style={{ ...mono, fontSize: 10, color: "var(--ak-text-subtle)", marginLeft: "auto", display: "inline-block", transition: "transform 0.2s", transform: expandedStep === "failed" ? "rotate(180deg)" : "rotate(0deg)" }}>▾</span>
+                  </div>
+                  <p style={{ ...sans, fontSize: 12, color: "var(--ak-status-failed-color)", lineHeight: 1.55, margin: 0 }}>
+                    {events.find(e => e.status === "failed")?.description ?? DEFAULT_DESCRIPTIONS.failed[type]}
+                  </p>
+                  {events.find(e => e.status === "failed")?.timestamp && (
+                    <span style={{ ...mono, fontSize: 10, color: "var(--ak-status-failed-color)", marginTop: 4, display: "block" }}>
+                      {formatTs(events.find(e => e.status === "failed")!.timestamp)}
+                    </span>
+                  )}
                 </div>
-                <p style={{ ...sans, fontSize: 12, color: "var(--ak-status-failed-color)", lineHeight: 1.55, margin: 0 }}>
-                  {events.find(e => e.status === "failed")?.description ?? DEFAULT_DESCRIPTIONS.failed[type]}
-                </p>
-                {events.find(e => e.status === "failed")?.timestamp && (
-                  <span style={{ ...mono, fontSize: 10, color: "var(--ak-status-failed-color)", marginTop: 4, display: "block" }}>
-                    {formatTs(events.find(e => e.status === "failed")!.timestamp)}
-                  </span>
-                )}
+                {expandedStep === "failed" && (() => {
+                  const ev = events.find(e => e.status === "failed");
+                  return (
+                    <div style={{ marginTop: 10, padding: "12px 14px", borderRadius: 10, border: "1px solid var(--ak-status-failed-border)", background: "var(--ak-status-failed-bg)", display: "flex", flexDirection: "column", gap: 8 }}>
+                      {ev?.timestamp && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-status-failed-color)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Timestamp</span>
+                          <span style={{ ...mono, fontSize: 11, color: "var(--ak-status-failed-color)" }}>{ev.timestamp}</span>
+                        </div>
+                      )}
+                      {ev?.error && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-status-failed-color)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Error</span>
+                          <span style={{ ...mono, fontSize: 11, color: "var(--ak-status-failed-color)" }}>{ev.error}</span>
+                        </div>
+                      )}
+                      {ev?.rawApiResponse !== undefined && (
+                        <div>
+                          <span style={{ ...mono, fontSize: 9, letterSpacing: "0.1em", color: "var(--ak-status-failed-color)", textTransform: "uppercase", display: "block", marginBottom: 2 }}>Raw API Response</span>
+                          <pre style={{ ...mono, fontSize: 10, color: "var(--ak-status-failed-color)", background: "var(--ak-surface-3)", padding: "10px 12px", borderRadius: 8, border: "1px solid var(--ak-status-failed-border)", overflowX: "auto", margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-all", maxHeight: 200, overflowY: "auto" }}>
+                            {JSON.stringify(ev.rawApiResponse, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

Closes #680

TransactionTimeline steps were rendered as a flat, read-only list with no way for users to inspect the underlying data for each step. This PR adds click-to-expand detail panels that reveal the raw API response, timestamp, and error (if any) for each step.

## Changes

### `TransactionTimeline.tsx`
- **`TxEvent` interface** — added two optional fields:
  - `rawApiResponse?: unknown` — the raw anchor API response payload for that step
  - `error?: string` — a human-readable error message if this step errored
- **`expandedStep` state** (`TxStatus | null`) — tracks which step's detail panel is currently open; only one can be open at a time
- **Clickable step headers** — each step's label/description row is wrapped in a `div` with `onClick` that toggles `expandedStep`; a chevron (▾) rotates 180° when the panel is open
- **Detail panel** — rendered below each step when expanded; shows:
  - ISO timestamp (full, not abbreviated)
  - Error message (in red accent) when `error` is set
  - Pretty-printed JSON of `rawApiResponse` in a scrollable `<pre>` block (max-height 200px)
  - Fallback "No additional details available." when the event has none of the above
- **Terminal nodes** — the appended `failed` node has the same expand/collapse behaviour, including `rawApiResponse` and `error` support; the `refunded` node retains its existing appearance (no interactive data typically available)
- **`txHash` link** — `e.stopPropagation()` added so clicking the Stellar explorer link doesn't toggle the panel

### `TransactionTimeline.stories.tsx`
- `PENDING_EVENTS` fixtures updated with realistic `rawApiResponse` payloads (SEP-24 transaction objects) for the initiated, awaiting_user, and pending steps
- `FAILED_EVENTS` fixture updated with an `error` string and `rawApiResponse` on the failed event to demonstrate the error panel

## Behaviour

| Interaction | Result |
|---|---|
| Click any step header | Expand detail panel for that step |
| Click expanded step header | Collapse panel |
| Click a different step | Only that step expands (previous closes) |
| Click Stellar tx hash link | Opens explorer tab; panel state unchanged |

## Testing

No test changes — existing tests cover component rendering and are unaffected by the new optional fields and conditional UI.