### PR TITLE
feat: add AnchorHealthBadge component (#683)

### DIFF
--- a/storybook/AnchorHealthBadge.stories.tsx
+++ b/storybook/AnchorHealthBadge.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AnchorHealthBadge } from '../ui/components/AnchorHealthBadge';
+
+const meta = {
+  title: 'Components/AnchorHealthBadge',
+  component: AnchorHealthBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    score: { control: { type: 'range', min: 0, max: 100 } },
+    showScore: { control: 'boolean' },
+  },
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof AnchorHealthBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Healthy: Story = {
+  name: 'Healthy (≥80)',
+  args: { score: 95, showScore: true },
+};
+
+export const Fair: Story = {
+  name: 'Fair (60–79)',
+  args: { score: 68, showScore: true },
+};
+
+export const Poor: Story = {
+  name: 'Poor (<60)',
+  args: { score: 32, showScore: true },
+};
+
+export const NoScore: Story = {
+  name: 'Label only (showScore=false)',
+  args: { score: 85, showScore: false },
+};
+
+export const AllTiers: Story = {
+  name: 'All tiers side by side',
+  render: () => (
+    <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+      <AnchorHealthBadge score={90} />
+      <AnchorHealthBadge score={65} />
+      <AnchorHealthBadge score={40} />
+      <AnchorHealthBadge score={0} />
+    </div>
+  ),
+};

--- a/ui/components/AnchorHealthBadge.tsx
+++ b/ui/components/AnchorHealthBadge.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+
+export interface AnchorHealthBadgeProps {
+  /** Health score 0–100 */
+  score: number;
+  /** Optionally show the numeric score inside the badge */
+  showScore?: boolean;
+  className?: string;
+}
+
+type Tier = { label: string; color: string; bg: string; border: string };
+
+function getTier(score: number): Tier {
+  if (score >= 80) return { label: 'Healthy', color: '#166534', bg: '#dcfce7', border: '#86efac' };
+  if (score >= 60) return { label: 'Fair',    color: '#92400e', bg: '#fef9c3', border: '#fde047' };
+  return               { label: 'Poor',     color: '#991b1b', bg: '#fee2e2', border: '#fca5a5' };
+}
+
+export function AnchorHealthBadge({ score, showScore = true, className }: AnchorHealthBadgeProps) {
+  const clamped = Math.max(0, Math.min(100, Math.round(score)));
+  const tier = getTier(clamped);
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <span
+      role="status"
+      aria-label={`Anchor health: ${tier.label} (${clamped}/100)`}
+      className={className}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        border: `1px solid ${tier.border}`,
+        background: tier.bg,
+        color: tier.color,
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        lineHeight: '1.5',
+        userSelect: 'none',
+        cursor: 'default',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true" style={{ fontSize: '0.6rem' }}>●</span>
+      {tier.label}
+      {showScore && <span style={{ opacity: 0.75 }}>· {clamped}</span>}
+
+      {hovered && (
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#1e293b',
+            color: '#f8fafc',
+            fontSize: '0.7rem',
+            padding: '4px 8px',
+            borderRadius: '4px',
+            whiteSpace: 'nowrap',
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        >
+          Health score: {clamped}/100
+        </span>
+      )}
+    </span>
+  );
+}

--- a/ui/components/index.ts
+++ b/ui/components/index.ts
@@ -6,3 +6,6 @@
 
 export { ApiRequestPanel } from './ApiRequestPanel';
 export type { ApiRequestPanelProps } from './ApiRequestPanel';
+
+export { AnchorHealthBadge } from './AnchorHealthBadge';
+export type { AnchorHealthBadgeProps } from './AnchorHealthBadge';


### PR DESCRIPTION
## Summary

Closes #683

Adds a standalone `AnchorHealthBadge` component that maps a 0–100 health score to colour-coded tiers, with an accessible `aria-label` and a hover tooltip.

---

## What changed

### `ui/components/AnchorHealthBadge.tsx` (new)

| Score range | Tier label | Colour |
|-------------|-----------|--------|
| 80 – 100    | Healthy   | Green  |
| 60 – 79     | Fair      | Yellow |
| 0 – 59      | Poor      | Red    |

- Accepts a `score: number` prop (clamped to 0–100).
- Optional `showScore` prop (default `true`) controls whether the numeric value appears inside the badge.
- `role="status"` + `aria-label` surface tier and score to screen readers without extra markup.
- Hover tooltip (`role="tooltip"`) shows `Health score: N/100` via inline React state — no external dependency.
- Pure inline styles; no new CSS file or external class names needed.

### `storybook/AnchorHealthBadge.stories.tsx` (new)

Five stories covering all states:
- **Healthy (≥80)** – score 95
- **Fair (60–79)** – score 68
- **Poor (<60)** – score 32
- **Label only** – `showScore=false`
- **All tiers side by side** – render story showing all four edge values (90, 65, 40, 0)

### `ui/components/index.ts` (modified)

Exports `AnchorHealthBadge` and `AnchorHealthBadgeProps` alongside existing exports.

---

## How to test locally

```bash
cd ui
npm install
npm run storybook
# Open Components/AnchorHealthBadge
```

Or import directly:

```tsx
import { AnchorHealthBadge } from 'ui/components';

<AnchorHealthBadge score={72} />          // Fair – yellow
<AnchorHealthBadge score={91} />          // Healthy – green
<AnchorHealthBadge score={30} />          // Poor – red
<AnchorHealthBadge score={85} showScore={false} />  // Label only
```

---

## Checklist

- [x] Component maps 0-100 → red / yellow / green
- [x] `aria-label` includes tier and numeric score
- [x] Hover tooltip with numeric score
- [x] Exported from `ui/components/index.ts`
- [x] Storybook stories for all tiers